### PR TITLE
Add index.html skeleton for electron app

### DIFF
--- a/electron-app/index.html
+++ b/electron-app/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Lead Notifier</title>
+  </head>
+  <body>
+    <div id="lead-log"></div>
+    <script type="module" src="renderer.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add basic HTML entry point with lead log container
- load renderer logic via module script

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a3298f164832580f2c9aeb35a2426