### PR TITLE
Fix audio notification path in renderer

### DIFF
--- a/electron-app/renderer.js
+++ b/electron-app/renderer.js
@@ -35,7 +35,7 @@ const openai = new OpenAI({
 const leadLog = document.getElementById("lead-log");
 
 const playSound = () => {
-  const audio = new Audio("notify.mp3"); // Place sound file in `public/`
+  const audio = new Audio("sounds/notification.mp3");
   audio.play();
 };
 


### PR DESCRIPTION
## Summary
- use existing `sounds/notification.mp3` file when playing notification sound

## Testing
- `node -e "const fs=require('fs'); const path=require('path'); console.log(fs.existsSync(path.join(__dirname,'sounds','notification.mp3')));"`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a329dc8988325b2d8bc27cd83e0c0