### PR TITLE
refactor env handling in renderer

### DIFF
--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -3,6 +3,24 @@ const { app, BrowserWindow, Tray, Menu, nativeImage } = require('electron');
 const path = require('path');
 require('dotenv').config(); // ✅ Load .env for Firebase keys
 
+// Ensure required environment variables are present
+const REQUIRED_ENV_VARS = [
+  'FIREBASE_API_KEY',
+  'FIREBASE_AUTH_DOMAIN',
+  'FIREBASE_PROJECT_ID',
+  'FIREBASE_STORAGE_BUCKET',
+  'FIREBASE_MESSAGING_SENDER_ID',
+  'FIREBASE_APP_ID',
+  'OPENAI_API_KEY',
+];
+
+for (const key of REQUIRED_ENV_VARS) {
+  if (!process.env[key]) {
+    console.error(`Missing required environment variable: ${key}`);
+    process.exit(1);
+  }
+}
+
 let tray = null;
 let win;
 

--- a/electron-app/preload.js
+++ b/electron-app/preload.js
@@ -1,8 +1,6 @@
 // preload.js
 
 const { contextBridge } = require('electron');
-const dotenv = require('dotenv');
-dotenv.config();
 
 contextBridge.exposeInMainWorld('electronAPI', {
   getEnv: (key) => process.env[key] || null,

--- a/electron-app/renderer.js
+++ b/electron-app/renderer.js
@@ -6,19 +6,16 @@ import {
   query,
   orderBy,
 } from "firebase/firestore";
-import { config } from "dotenv";
 import OpenAI from "openai";
-
-config();
 
 // Firebase config
 const firebaseConfig = {
-  apiKey: process.env.FIREBASE_API_KEY,
-  authDomain: process.env.FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.FIREBASE_PROJECT_ID,
-  storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.FIREBASE_APP_ID,
+  apiKey: window.electronAPI.getEnv('FIREBASE_API_KEY'),
+  authDomain: window.electronAPI.getEnv('FIREBASE_AUTH_DOMAIN'),
+  projectId: window.electronAPI.getEnv('FIREBASE_PROJECT_ID'),
+  storageBucket: window.electronAPI.getEnv('FIREBASE_STORAGE_BUCKET'),
+  messagingSenderId: window.electronAPI.getEnv('FIREBASE_MESSAGING_SENDER_ID'),
+  appId: window.electronAPI.getEnv('FIREBASE_APP_ID'),
 };
 
 // Init Firebase
@@ -27,7 +24,7 @@ const db = getFirestore(app);
 
 // OpenAI
 const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
+  apiKey: window.electronAPI.getEnv('OPENAI_API_KEY'),
   dangerouslyAllowBrowser: true,
 });
 


### PR DESCRIPTION
## Summary
- use electron preload bridge to access env variables instead of dotenv in renderer
- validate required environment variables on app startup

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_689a32a0d9288325806a6768051342b5