### PR TITLE
Reuse notification audio object

### DIFF
--- a/electron-app/renderer.js
+++ b/electron-app/renderer.js
@@ -31,9 +31,12 @@ const openai = new OpenAI({
 // UI Helpers
 const leadLog = document.getElementById("lead-log");
 
+// Reuse audio object to avoid recreating it on each notification
+const notificationSound = new Audio("sounds/notification.mp3");
+
 const playSound = () => {
-  const audio = new Audio("sounds/notification.mp3");
-  audio.play();
+  notificationSound.currentTime = 0;
+  notificationSound.play();
 };
 
 const notifyLead = (lead) => {


### PR DESCRIPTION
## Summary
- reuse notification sound object so audio isn't re-created each time

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a312d92888325a28333ebdddd060c