### PR TITLE
Add modal for AI reply display

### DIFF
--- a/electron-app/index.html
+++ b/electron-app/index.html
@@ -3,9 +3,52 @@
   <head>
     <meta charset="UTF-8" />
     <title>Lead Notifier</title>
+    <style>
+      .modal {
+        display: none;
+        position: fixed;
+        z-index: 1000;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        overflow: auto;
+        background-color: rgba(0, 0, 0, 0.4);
+      }
+
+      .modal-content {
+        background-color: #fefefe;
+        margin: 15% auto;
+        padding: 20px;
+        border: 1px solid #888;
+        width: 80%;
+        max-width: 500px;
+        box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+      }
+
+      .close {
+        color: #aaa;
+        float: right;
+        font-size: 28px;
+        font-weight: bold;
+        cursor: pointer;
+      }
+
+      .close:hover,
+      .close:focus {
+        color: #000;
+        text-decoration: none;
+      }
+    </style>
   </head>
   <body>
     <div id="lead-log"></div>
+    <div id="ai-modal" class="modal">
+      <div class="modal-content">
+        <span id="close-modal" class="close">&times;</span>
+        <pre id="ai-modal-text"></pre>
+      </div>
+    </div>
     <script type="module" src="renderer.js"></script>
   </body>
 </html>

--- a/electron-app/renderer.js
+++ b/electron-app/renderer.js
@@ -30,6 +30,24 @@ const openai = new OpenAI({
 
 // UI Helpers
 const leadLog = document.getElementById("lead-log");
+const modal = document.getElementById("ai-modal");
+const modalText = document.getElementById("ai-modal-text");
+const closeModal = document.getElementById("close-modal");
+
+closeModal.addEventListener("click", () => {
+  modal.style.display = "none";
+});
+
+window.addEventListener("click", (event) => {
+  if (event.target === modal) {
+    modal.style.display = "none";
+  }
+});
+
+const showModal = (message) => {
+  modalText.textContent = message;
+  modal.style.display = "block";
+};
 
 // Reuse audio object to avoid recreating it on each notification
 const notificationSound = new Audio("sounds/notification.mp3");
@@ -99,8 +117,6 @@ onSnapshot(q, async (snapshot) => {
 
     const aiReply = await generateReply(lead);
     console.log("✍️ AI Suggestion:", aiReply);
-
-    // Optional: display in popup/modal if needed
-    alert(`AI Response:\n${aiReply}`);
+    showModal(aiReply);
   }
 });


### PR DESCRIPTION
## Summary
- add modal component markup and styles
- show AI-generated reply in modal instead of alert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a39c633488325ac643eba01bc7709