### PR TITLE
Prompt notification permission before showing desktop alerts

### DIFF
--- a/electron-app/renderer.js
+++ b/electron-app/renderer.js
@@ -49,12 +49,24 @@ const notifyLead = (lead) => {
 💬 Comments: ${comments || "None"}
 `;
 
-  new Notification(`🔥 New Lead: ${first_name} ${last_name}`, {
-    body,
-    silent: false,
-  });
+  const showNotification = () => {
+    new Notification(`🔥 New Lead: ${first_name} ${last_name}`, {
+      body,
+      silent: false,
+    });
 
-  playSound();
+    playSound();
+  };
+
+  if (Notification.permission === "default") {
+    Notification.requestPermission().then((permission) => {
+      if (permission === "granted") {
+        showNotification();
+      }
+    });
+  } else if (Notification.permission === "granted") {
+    showNotification();
+  }
 };
 
 const logLeadToUI = (lead) => {


### PR DESCRIPTION
## Summary
- Ensure notification permission is granted before showing new lead notifications

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_689a39c35e9883259885bb1d8533c3e3