### PR TITLE
Use env var for Google Sheet ID

### DIFF
--- a/electron-app/.env.example
+++ b/electron-app/.env.example
@@ -1,0 +1,1 @@
+GOOGLE_SHEET_ID=

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,9 @@
 {
   "functions": {
     "source": "functions",
-    "runtime": "nodejs20"
+    "runtime": "nodejs20",
+    "env": {
+      "GOOGLE_SHEET_ID": ""
+    }
   }
 }

--- a/functions/.env.example
+++ b/functions/.env.example
@@ -1,0 +1,1 @@
+GOOGLE_SHEET_ID=

--- a/functions/googleSheet.js
+++ b/functions/googleSheet.js
@@ -9,7 +9,7 @@ const auth = new google.auth.GoogleAuth({
   scopes: ["https://www.googleapis.com/auth/spreadsheets"],
 });
 
-const SPREADSHEET_ID = "1DfjUU--9m4LOGDLhYV6SvWg1OkDbuZrj1eeapAEV2rU";
+const SPREADSHEET_ID = process.env.GOOGLE_SHEET_ID;
 const SHEET_NAME = "Leads"; // This must match your sheet tab name exactly (case-sensitive)
 
 async function appendLeadToSheet(lead) {


### PR DESCRIPTION
## Summary
- load Google Sheet ID from `GOOGLE_SHEET_ID` env var
- document `GOOGLE_SHEET_ID` in `.env.example` files
- expose `GOOGLE_SHEET_ID` in Firebase config

## Testing
- `cd functions && npm test` *(fails: Missing script: "test")*
- `cd electron-app && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a39bd4fe88325820856e6166bf005