### PR TITLE
Add email lead handler function

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,9 +1,12 @@
 {
-  "functions": {
-    "source": "functions",
-    "runtime": "nodejs20",
-    "env": {
-      "GOOGLE_SHEET_ID": ""
+    "functions": {
+        "source": "functions",
+        "runtime": "nodejs20",
+        "env": {
+            "GOOGLE_SHEET_ID": ""
+        },
+        "endpoints": {
+            "receiveEmailLead": {}
+        }
     }
-  }
 }

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -10,7 +10,8 @@
         "dotenv": "^17.2.1",
         "firebase-admin": "^11.10.1",
         "firebase-functions": "^4.5.0",
-        "googleapis": "^133.0.0"
+        "googleapis": "^133.0.0",
+        "xml2js": "^0.6.2"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -3087,6 +3088,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -3602,6 +3609,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/xmlcreate": {
       "version": "2.0.4",

--- a/functions/package.json
+++ b/functions/package.json
@@ -5,6 +5,7 @@
     "dotenv": "^17.2.1",
     "firebase-admin": "^11.10.1",
     "firebase-functions": "^4.5.0",
-    "googleapis": "^133.0.0"
+    "googleapis": "^133.0.0",
+    "xml2js": "^0.6.2"
   }
 }


### PR DESCRIPTION
## Summary
- remove deprecated receiveCallDripLead function
- add receiveEmailLead function parsing plain text or ADF/XML emails and storing leads
- include xml2js dependency and expose receiveEmailLead in firebase.json

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689a3e495b608325ba7ac9f4b40349eb