### PR TITLE
Use fast-xml-parser for ADF emails

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -8,10 +8,10 @@
         "cors": "^2.8.5",
         "dayjs": "^1.11.13",
         "dotenv": "^17.2.1",
+        "fast-xml-parser": "^4.5.3",
         "firebase-admin": "^11.10.1",
         "firebase-functions": "^4.5.0",
-        "googleapis": "^133.0.0",
-        "xml2js": "^0.6.2"
+        "googleapis": "^133.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -1347,7 +1347,6 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "strnum": "^1.1.1"
       },
@@ -3088,12 +3087,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
-    "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "license": "ISC"
-    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -3347,8 +3340,7 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/stubs": {
       "version": "3.0.0",
@@ -3609,28 +3601,6 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC",
       "optional": true
-    },
-    "node_modules/xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "license": "MIT",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
     },
     "node_modules/xmlcreate": {
       "version": "2.0.4",

--- a/functions/package.json
+++ b/functions/package.json
@@ -6,6 +6,6 @@
     "firebase-admin": "^11.10.1",
     "firebase-functions": "^4.5.0",
     "googleapis": "^133.0.0",
-    "xml2js": "^0.6.2"
+    "fast-xml-parser": "^4.5.3"
   }
 }


### PR DESCRIPTION
## Summary
- Replace xml2js with fast-xml-parser and parse the full message body
- Validate that parsed JSON contains `adf` before processing, logging an error otherwise
- Add fast-xml-parser to Cloud Functions dependencies

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a59a8ad408325bc7467c35b05960b