### PR TITLE
Flag emails only after successful processing

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -75,9 +75,20 @@ exports.receiveEmailLead = functions.https.onRequest(async (req, res) => {
     }
 
     await admin.firestore().collection("leads").add(lead);
+
+    // Only mark the email as seen after it has been successfully stored
+    if (
+      typeof client !== "undefined" &&
+      typeof msg !== "undefined" &&
+      msg?.uid
+    ) {
+      await client.messageFlagsAdd(msg.uid, ["\\Seen"]);
+    }
+
     res.status(200).send("✅ Lead received and parsed.");
   } catch (err) {
     console.error("❌ Error handling email lead:", err);
+    // Skipping flagging so the email can be retried later
     res.status(500).send("❌ Failed to process email lead.");
   }
 });


### PR DESCRIPTION
## Summary
- Only mark emails as `\Seen` after a lead is added successfully
- Log errors and skip flagging so failed emails can be retried

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd functions && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a59a77350832596a1a2560ecd7de9