### PR TITLE
Add basic test placeholders for CI

### DIFF
--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -4,7 +4,8 @@
   "description": "Electron app that shows a desktop notification when a new lead is added to Firestore.",
   "main": "main.js",
   "scripts": {
-    "start": "electron ."
+    "start": "electron .",
+    "test": "node test/smoke.test.js"
   },
   "author": "Rob Brasco",
   "license": "MIT",

--- a/electron-app/test/smoke.test.js
+++ b/electron-app/test/smoke.test.js
@@ -1,0 +1,6 @@
+const assert = require('assert');
+
+// Simple smoke test to ensure the test runner is wired up.
+assert.strictEqual(1 + 1, 2);
+
+console.log('Electron app tests passed');

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "test": "node test/smoke.test.js"
+  },
   "dependencies": {
     "cors": "^2.8.5",
     "dayjs": "^1.11.13",

--- a/functions/test/smoke.test.js
+++ b/functions/test/smoke.test.js
@@ -1,0 +1,6 @@
+const assert = require('assert');
+
+// Simple smoke test to ensure the test runner is wired up.
+assert.ok(true, 'basic assertion should pass');
+
+console.log('Functions tests passed');


### PR DESCRIPTION
## Summary
- add npm test scripts to electron app and functions packages
- provide simple smoke tests using Node's assert module

## Testing
- `npm test` (electron-app)
- `npm test` (functions)


------
https://chatgpt.com/codex/tasks/task_e_689a63227518832595973ee2f1544407