### PR TITLE
refactor: centralize xml helper functions

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -3,12 +3,7 @@ const functions = require("firebase-functions");
 const admin = require("firebase-admin");
 const { XMLParser } = require("fast-xml-parser");
 const { extractLeadFromContact } = require("./adfEmailHandler");
-
-const getFirst = (prop) => (Array.isArray(prop) ? prop[0] : prop);
-const getText = (prop) => {
-  const val = getFirst(prop);
-  return (val && typeof val === "object") ? (val["#text"] || "") : (val || "");
-};
+const { getFirst, getText } = require("./utils");
 
 // Optional: verify webhook signatures or authenticate with Gmail API
 const gmailWebhookSecret = process.env.GMAIL_WEBHOOK_SECRET;

--- a/functions/utils.js
+++ b/functions/utils.js
@@ -1,0 +1,7 @@
+const getFirst = (prop) => (Array.isArray(prop) ? prop[0] : prop);
+const getText = (prop) => {
+  const val = getFirst(prop);
+  return (val && typeof val === "object") ? (val["#text"] || "") : (val || "");
+};
+
+module.exports = { getFirst, getText };


### PR DESCRIPTION
## Summary
- centralize XML parsing helpers for arrays and text
- simplify lead extraction using new helpers

## Testing
- `cd functions && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b4d44d5088325918866ef8cf5a935