### PR TITLE
feat: migrate leads to leads_v2 collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Priority Lead Sync
 
-This project collects lead information and stores it in Firebase Firestore and a Google Sheet.
+This project collects lead information and stores it in Firebase Firestore (under the `leads_v2` collection) and a Google Sheet.
 
 ## Cloud Function
 
-The `functions` directory contains a Firebase Cloud Function named `receiveEmailLead`. It accepts an HTTP `POST` request with lead fields such as name, phone, email, comments, vehicle, and trade. The parsed lead is saved to Firestore for later use.
+The `functions` directory contains a Firebase Cloud Function named `receiveEmailLead`. It accepts an HTTP `POST` request with lead fields such as name, phone, email, comments, vehicle, and trade. The parsed lead is saved to the `leads_v2` Firestore collection for later use.
 
 If the write to Firestore fails, the email remains unread so the polling process can automatically retry on a subsequent run.
 
@@ -22,7 +22,7 @@ If the write to Firestore fails, the email remains unread so the polling process
 
 ## Electron Notifier
 
-The `electron-app` directory provides a small Electron application that listens for new leads in Firestore and displays desktop notifications.
+The `electron-app` directory provides a small Electron application that listens for new leads in the `leads_v2` Firestore collection and displays desktop notifications.
 
 ## Environment Variables
 

--- a/electron-app/renderer.js
+++ b/electron-app/renderer.js
@@ -138,7 +138,7 @@ const generateReply = async (lead) => {
 };
 
 // Live Listener
-const q = query(collection(db, "leads"), orderBy("receivedAt", "desc"));
+const q = query(collection(db, "leads_v2"), orderBy("receivedAt", "desc"));
 
 onSnapshot(q, async (snapshot) => {
   const latest = snapshot.docChanges().filter((change) => change.type === "added");

--- a/functions/index.js
+++ b/functions/index.js
@@ -87,7 +87,10 @@ exports.receiveEmailLead = functions.https.onRequest(async (req, res) => {
 
     // Store the lead and only mark the message as seen if the write succeeds
     try {
-      await admin.firestore().collection("leads").add(lead);
+      await admin.firestore().collection("leads_v2").add({
+        ...lead,
+        ingestor: "receiveLead_v2",
+      });
 
       if (
         typeof client !== "undefined" &&


### PR DESCRIPTION
## Summary
- store incoming leads in new `leads_v2` Firestore collection with `ingestor` metadata
- update Electron app to watch `leads_v2` instead of legacy `leads`
- document new `leads_v2` collection usage

## Testing
- `cd functions && npm test`
- `cd ../electron-app && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b4e8aed948325851bd48b80ae58fd