### PR TITLE
Verify Gmail webhook secret

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -12,6 +12,13 @@ admin.initializeApp();
 
 exports.receiveEmailLead = functions.https.onRequest(async (req, res) => {
   try {
+    if (
+      !req.headers["x-webhook-secret"] ||
+      req.headers["x-webhook-secret"] !== gmailWebhookSecret
+    ) {
+      return res.status(401).send("Unauthorized");
+    }
+
     let bodyText = "";
 
     if (typeof req.body === "string") {

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test": "node test/smoke.test.js"
+    "test": "node test/smoke.test.js && node test/webhook-secret.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/functions/test/webhook-secret.test.js
+++ b/functions/test/webhook-secret.test.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+
+process.env.GMAIL_WEBHOOK_SECRET = 'expected-secret';
+const { receiveEmailLead } = require('../index.js');
+
+const run = async (headers) => {
+  let statusCode;
+  const res = {
+    status: (code) => {
+      statusCode = code;
+      return { send: () => {} };
+    },
+  };
+  await receiveEmailLead({ headers }, res);
+  return statusCode;
+};
+
+(async () => {
+  const missing = await run({});
+  assert.strictEqual(missing, 401, 'should reject when secret missing');
+
+  const wrong = await run({ 'x-webhook-secret': 'wrong' });
+  assert.strictEqual(wrong, 401, 'should reject when secret mismatched');
+
+  console.log('Webhook secret tests passed');
+})();


### PR DESCRIPTION
## Summary
- reject requests missing or mismatching the `x-webhook-secret` header
- add unit test for unauthorized webhook requests

## Testing
- `cd functions && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b994ed71483259a495cddb8f24d51