### PR TITLE
refactor(functions): use Firebase secrets

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,17 +1,17 @@
-require("dotenv").config();
-const functions = require("firebase-functions");
 const admin = require("firebase-admin");
+const { onRequest } = require("firebase-functions/v2/https");
+const { defineSecret } = require("firebase-functions/params");
 const { XMLParser } = require("fast-xml-parser");
 const { extractLeadFromContact } = require("./adfEmailHandler");
 const { getFirst, getText } = require("./utils");
 const { setSecretOnce } = require("./setSecretOnce");
 
-// Optional: verify webhook signatures or authenticate with Gmail API
-const gmailWebhookSecret = process.env.GMAIL_WEBHOOK_SECRET;
+const GMAIL_WEBHOOK_SECRET = defineSecret("GMAIL_WEBHOOK_SECRET");
+const OPENAI_API_KEY = defineSecret("OPENAI_API_KEY");
 
 admin.initializeApp();
 
-exports.setSecretOnce = functions.https.onRequest((req, res) => {
+exports.setSecretOnce = onRequest({ secrets: [GMAIL_WEBHOOK_SECRET] }, (req, res) => {
   try {
     setSecretOnce();
     res.status(200).send("Secret set");
@@ -21,113 +21,119 @@ exports.setSecretOnce = functions.https.onRequest((req, res) => {
   }
 });
 
-exports.receiveEmailLead = functions.https.onRequest(async (req, res) => {
-  try {
-    if (
-      !req.headers["x-webhook-secret"] ||
-      req.headers["x-webhook-secret"] !== gmailWebhookSecret
-    ) {
-      return res.status(401).send("Unauthorized");
-    }
-
-    let bodyText = "";
-
-    if (typeof req.body === "string") {
-      bodyText = req.body;
-    } else if (req.body && req.body.text) {
-      bodyText = req.body.text;
-    } else if (req.rawBody) {
-      bodyText = req.rawBody.toString();
-    }
-
-    let lead = {
-      first_name: null,
-      last_name: null,
-      phone: null,
-      email: null,
-      comments: "",
-      vehicle: "",
-      trade: "",
-      receivedAt: new Date().toISOString()
-    };
-
-    if (/(<adf>|<\?xml)/i.test(bodyText) || (req.headers["content-type"] || "").includes("xml")) {
-      const parser = new XMLParser({ ignoreAttributes: false, isArray: () => true });
-      const json = parser.parse(bodyText);
-      if (!json?.adf) {
-        console.error("❌ Parsing error: json.adf not found.");
-        return res.status(400).send("❌ Failed to process email lead.");
-      }
-      const adf = json.adf;
-      const prospect = getFirst(adf.prospect);
-      const customer = getFirst(prospect?.customer);
-      const contact = getFirst(customer?.contact);
-
-      const { firstName, lastName, phone, email } = extractLeadFromContact(contact || {});
-      const comments = getText(prospect?.comments);
-      const vehicle = getText(getFirst(prospect?.vehicle)?.description);
-      const trade = getText(getFirst(prospect?.trade_in)?.description);
-
-      lead = {
-        ...lead,
-        first_name: firstName || null,
-        last_name: lastName || null,
-        phone: phone || null,
-        email: email || null,
-        comments,
-        vehicle,
-        trade
-      };
-    } else {
-      const lines = bodyText.split(/\r?\n/);
-      const getValue = (label) => {
-        const line = lines.find((l) => l.toLowerCase().startsWith(label.toLowerCase()));
-        return line ? line.split(":").slice(1).join(":").trim() : "";
-      };
-
-      const fullName = getValue("Name");
-      const [firstName = "", lastName = ""] = fullName.split(" ");
-      lead.first_name = firstName || null;
-      lead.last_name = lastName || null;
-      lead.phone = getValue("Phone") || null;
-      lead.email = getValue("Email") || null;
-      lead.comments = getValue("Comments");
-      lead.vehicle = getValue("Vehicle");
-      lead.trade = getValue("Trade");
-    }
-
-    const requiredFields = ["first_name", "last_name", "phone", "email"];
-    const missingFields = requiredFields.filter((field) => !lead[field]);
-
-    if (missingFields.length > 0) {
-      return res.status(400).send(`Missing required fields: ${missingFields.join(", ")}`);
-    }
-
-    // Store the lead and only mark the message as seen if the write succeeds
+exports.receiveEmailLead = onRequest(
+  { secrets: [GMAIL_WEBHOOK_SECRET, OPENAI_API_KEY] },
+  async (req, res) => {
     try {
-      await admin.firestore().collection("leads_v2").add({
-        ...lead,
-        ingestor: "receiveLead_v2",
-      });
-
+      const gmailWebhookSecret = GMAIL_WEBHOOK_SECRET.value();
       if (
-        typeof client !== "undefined" &&
-        typeof msg !== "undefined" &&
-        msg?.uid
+        !req.headers["x-webhook-secret"] ||
+        req.headers["x-webhook-secret"] !== gmailWebhookSecret
       ) {
-        await client.messageFlagsAdd(msg.uid, ["\\Seen"]);
+        return res.status(401).send("Unauthorized");
       }
-    } catch (error) {
-      console.error("❌ Firestore write failed:", error);
-      // Skip flagging so the poller can retry
-      return res.status(500).send("❌ Failed to process email lead.");
-    }
 
-    res.status(200).send("✅ Lead received and parsed.");
-  } catch (err) {
-    console.error("❌ Error handling email lead:", err);
-    // Skipping flagging so the email can be retried later
-    res.status(500).send("❌ Failed to process email lead.");
+      let bodyText = "";
+
+      if (typeof req.body === "string") {
+        bodyText = req.body;
+      } else if (req.body && req.body.text) {
+        bodyText = req.body.text;
+      } else if (req.rawBody) {
+        bodyText = req.rawBody.toString();
+      }
+
+      let lead = {
+        first_name: null,
+        last_name: null,
+        phone: null,
+        email: null,
+        comments: "",
+        vehicle: "",
+        trade: "",
+        receivedAt: new Date().toISOString()
+      };
+
+      if (/(<adf>|<\?xml)/i.test(bodyText) || (req.headers["content-type"] || "").includes("xml")) {
+        const parser = new XMLParser({ ignoreAttributes: false, isArray: () => true });
+        const json = parser.parse(bodyText);
+        if (!json?.adf) {
+          console.error("❌ Parsing error: json.adf not found.");
+          return res.status(400).send("❌ Failed to process email lead.");
+        }
+        const adf = json.adf;
+        const prospect = getFirst(adf.prospect);
+        const customer = getFirst(prospect?.customer);
+        const contact = getFirst(customer?.contact);
+
+        const { firstName, lastName, phone, email } = extractLeadFromContact(contact || {});
+        const comments = getText(prospect?.comments);
+        const vehicle = getText(getFirst(prospect?.vehicle)?.description);
+        const trade = getText(getFirst(prospect?.trade_in)?.description);
+
+        lead = {
+          ...lead,
+          first_name: firstName || null,
+          last_name: lastName || null,
+          phone: phone || null,
+          email: email || null,
+          comments,
+          vehicle,
+          trade
+        };
+      } else {
+        const lines = bodyText.split(/\r?\n/);
+        const getValue = (label) => {
+          const line = lines.find((l) => l.toLowerCase().startsWith(label.toLowerCase()));
+          return line ? line.split(":").slice(1).join(":").trim() : "";
+        };
+
+        const fullName = getValue("Name");
+        const [firstName = "", lastName = ""] = fullName.split(" ");
+        lead.first_name = firstName || null;
+        lead.last_name = lastName || null;
+        lead.phone = getValue("Phone") || null;
+        lead.email = getValue("Email") || null;
+        lead.comments = getValue("Comments");
+        lead.vehicle = getValue("Vehicle");
+        lead.trade = getValue("Trade");
+      }
+
+      const requiredFields = ["first_name", "last_name", "phone", "email"];
+      const missingFields = requiredFields.filter((field) => !lead[field]);
+
+      if (missingFields.length > 0) {
+        return res
+          .status(400)
+          .send(`Missing required fields: ${missingFields.join(", ")}`);
+      }
+
+      // Store the lead and only mark the message as seen if the write succeeds
+      try {
+        await admin.firestore().collection("leads_v2").add({
+          ...lead,
+          ingestor: "receiveLead_v2",
+        });
+
+        if (
+          typeof client !== "undefined" &&
+          typeof msg !== "undefined" &&
+          msg?.uid
+        ) {
+          await client.messageFlagsAdd(msg.uid, ["\\Seen"]);
+        }
+      } catch (error) {
+        console.error("❌ Firestore write failed:", error);
+        // Skip flagging so the poller can retry
+        return res.status(500).send("❌ Failed to process email lead.");
+      }
+
+      res.status(200).send("✅ Lead received and parsed.");
+    } catch (err) {
+      console.error("❌ Error handling email lead:", err);
+      // Skipping flagging so the email can be retried later
+      res.status(500).send("❌ Failed to process email lead.");
+    }
   }
-});
+);
 

--- a/functions/setSecretOnce.js
+++ b/functions/setSecretOnce.js
@@ -1,7 +1,9 @@
-require('dotenv').config();
+const { defineSecret } = require("firebase-functions/params");
+
+const GMAIL_WEBHOOK_SECRET = defineSecret("GMAIL_WEBHOOK_SECRET");
 
 function setSecretOnce() {
-  const secret = process.env.GMAIL_WEBHOOK_SECRET;
+  const secret = GMAIL_WEBHOOK_SECRET.value();
   if (!secret) {
     throw new Error('GMAIL_WEBHOOK_SECRET is not defined');
   }


### PR DESCRIPTION
## Summary
- use `defineSecret` for `GMAIL_WEBHOOK_SECRET` and `OPENAI_API_KEY`
- remove dotenv and process.env usage in Cloud Functions
- declare secrets in `onRequest` for webhook

## Testing
- `npm test --prefix functions`


------
https://chatgpt.com/codex/tasks/task_e_689bb2565c848325a40bdad6aaff7ff2