### PR TITLE
feat: validate request body and store webhook

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -7,10 +7,8 @@ admin.initializeApp();
 
 const receiveEmailLeadHandler = async (req, res) => {
   try {
-    if (
-      !req.headers["x-webhook-secret"] ||
-      req.headers["x-webhook-secret"] !== gmailWebhookSecret
-    ) {
+    const secret = req.headers["x-webhook-secret"];
+    if (!secret || secret !== gmailWebhookSecret) {
       return res.status(401).send("Unauthorized");
     }
 
@@ -23,11 +21,12 @@ const receiveEmailLeadHandler = async (req, res) => {
       return res.status(400).send("Body cannot be empty");
     }
 
+    const contentType = req.get("content-type") || null;
     const doc = {
       raw: bodyText,
       receivedAt: admin.firestore.FieldValue.serverTimestamp(),
       source: "gmail-webhook",
-      headers: { contentType: req.get("content-type") || null },
+      headers: { contentType },
     };
 
     try {

--- a/functions/test/body-validation.test.js
+++ b/functions/test/body-validation.test.js
@@ -24,5 +24,8 @@ const run = async (body) => {
   const empty = await run('');
   assert.strictEqual(empty, 400, 'should reject empty string body');
 
+  const notString = await run({});
+  assert.strictEqual(notString, 400, 'should reject non-string body');
+
   console.log('Body validation tests passed');
 })();


### PR DESCRIPTION
## Summary
- ensure Gmail webhook body is a string and non-empty before processing
- persist raw payload, server timestamp, source and content-type header to `leads_v2`
- extend tests for body validation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bcf85b8ac83259991ac26a8e90f16