### PR TITLE
Use Firebase params for secrets and remove dotenv

### DIFF
--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -1,7 +1,6 @@
 // main.js
 const { app, BrowserWindow, Tray, Menu, nativeImage } = require('electron');
 const path = require('path');
-require('dotenv').config(); // ✅ Load .env for Firebase keys
 
 // Ensure required environment variables are present
 const REQUIRED_ENV_VARS = [

--- a/electron-app/package-lock.json
+++ b/electron-app/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "auto-launch": "^5.0.6",
-        "dotenv": "^17.2.1",
         "electron": "^37.2.6",
         "electron-store": "^10.1.0",
         "firebase-admin": "^13.4.0",
@@ -1084,18 +1083,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.2.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
-      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -11,7 +11,6 @@
   "license": "MIT",
   "dependencies": {
     "auto-launch": "^5.0.6",
-    "dotenv": "^17.2.1",
     "electron": "^37.2.6",
     "electron-store": "^10.1.0",
     "firebase-admin": "^13.4.0",

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,15 +1,17 @@
 const { onRequest } = require("firebase-functions/v2/https");
+const { defineSecret } = require("firebase-functions/params");
 const admin = require("firebase-admin");
 
-const gmailWebhookSecret = process.env.GMAIL_WEBHOOK_SECRET;
+const gmailWebhookSecret = defineSecret("GMAIL_WEBHOOK_SECRET");
 
 admin.initializeApp();
 
 const receiveEmailLeadHandler = async (req, res) => {
   try {
+    const secret = gmailWebhookSecret.value();
     if (
       !req.headers["x-webhook-secret"] ||
-      req.headers["x-webhook-secret"] !== gmailWebhookSecret
+      req.headers["x-webhook-secret"] !== secret
     ) {
       return res.status(401).send("Unauthorized");
     }
@@ -43,5 +45,5 @@ const receiveEmailLeadHandler = async (req, res) => {
   }
 };
 
-exports.receiveEmailLead = onRequest(receiveEmailLeadHandler);
+exports.receiveEmailLead = onRequest({ secrets: [gmailWebhookSecret] }, receiveEmailLeadHandler);
 


### PR DESCRIPTION
## Summary
- Replace dotenv config with `defineSecret` from `firebase-functions/params` for `GMAIL_WEBHOOK_SECRET`
- Register secret with `onRequest` and reference its value inside the handler
- Drop dotenv dependency and import from the Electron app

## Testing
- `cd functions && npm test`
- `cd electron-app && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bcfa4b0dc8325b4a193216855ee2d