### PR TITLE
feat: use secret param for webhook

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,15 +1,16 @@
 const { onRequest } = require("firebase-functions/v2/https");
 const admin = require("firebase-admin");
+const { defineSecret } = require("firebase-functions/params");
 
-const gmailWebhookSecret = process.env.GMAIL_WEBHOOK_SECRET;
+const GMAIL_WEBHOOK_SECRET = defineSecret("GMAIL_WEBHOOK_SECRET");
 
 admin.initializeApp();
 
-const receiveEmailLeadHandler = async (req, res) => {
+const createReceiveEmailLeadHandler = (secret) => async (req, res) => {
   try {
     if (
       !req.headers["x-webhook-secret"] ||
-      req.headers["x-webhook-secret"] !== gmailWebhookSecret
+      req.headers["x-webhook-secret"] !== secret.value()
     ) {
       return res.status(401).send("Unauthorized");
     }
@@ -43,5 +44,10 @@ const receiveEmailLeadHandler = async (req, res) => {
   }
 };
 
-exports.receiveEmailLead = onRequest(receiveEmailLeadHandler);
+exports.receiveEmailLead = onRequest(
+  { secrets: [GMAIL_WEBHOOK_SECRET] },
+  createReceiveEmailLeadHandler(GMAIL_WEBHOOK_SECRET)
+);
+
+exports.createReceiveEmailLeadHandler = createReceiveEmailLeadHandler;
 

--- a/functions/test/body-validation.test.js
+++ b/functions/test/body-validation.test.js
@@ -1,7 +1,9 @@
 const assert = require('assert');
+const { createReceiveEmailLeadHandler } = require('../index.js');
 
-process.env.GMAIL_WEBHOOK_SECRET = 'expected-secret';
-const { receiveEmailLead } = require('../index.js');
+const receiveEmailLead = createReceiveEmailLeadHandler({
+  value: () => 'expected-secret',
+});
 
 const run = async (body) => {
   let statusCode;

--- a/functions/test/webhook-secret.test.js
+++ b/functions/test/webhook-secret.test.js
@@ -1,7 +1,9 @@
 const assert = require('assert');
+const { createReceiveEmailLeadHandler } = require('../index.js');
 
-process.env.GMAIL_WEBHOOK_SECRET = 'expected-secret';
-const { receiveEmailLead } = require('../index.js');
+const receiveEmailLead = createReceiveEmailLeadHandler({
+  value: () => 'expected-secret',
+});
 
 const run = async (headers) => {
   let statusCode;


### PR DESCRIPTION
## Summary
- use `defineSecret` for `GMAIL_WEBHOOK_SECRET`
- wire Cloud Function to receive secret and read via `value()`
- update tests to inject secret stub

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bcf9512c0832580831c3d122075fa