### PR TITLE
feat: use secret param for webhook

### DIFF
--- a/functions/test/body-validation.test.js
+++ b/functions/test/body-validation.test.js
@@ -1,14 +1,17 @@
 const assert = require('assert');
+const { createReceiveEmailLeadHandler } = require('../index.js');
 
-process.env.GMAIL_WEBHOOK_SECRET = 'expected-secret';
-const { receiveEmailLead } = require('../index.js');
+const receiveEmailLead = createReceiveEmailLeadHandler({
+  value: () => 'expected-secret',
+});
 
 const run = async (body) => {
   let statusCode;
+  const headers = { 'x-webhook-secret': 'expected-secret' };
   const req = {
-    headers: { 'x-webhook-secret': 'expected-secret' },
+    headers,
     body,
-    get: () => null,
+    get: (name) => headers[name.toLowerCase()] || null,
   };
   const res = {
     status: (code) => {

--- a/functions/test/webhook-secret.test.js
+++ b/functions/test/webhook-secret.test.js
@@ -1,17 +1,22 @@
 const assert = require('assert');
+const { createReceiveEmailLeadHandler } = require('../index.js');
 
-process.env.GMAIL_WEBHOOK_SECRET = 'expected-secret';
-const { receiveEmailLead } = require('../index.js');
+const receiveEmailLead = createReceiveEmailLeadHandler({
+  value: () => 'expected-secret',
+});
 
 const run = async (headers) => {
   let statusCode;
+  const req = {
+    get: (name) => headers[name.toLowerCase()],
+  };
   const res = {
     status: (code) => {
       statusCode = code;
       return { send: () => {} };
     },
   };
-  await receiveEmailLead({ headers }, res);
+  await receiveEmailLead(req, res);
   return statusCode;
 };
 


### PR DESCRIPTION
## Summary
- use `defineSecret` for `GMAIL_WEBHOOK_SECRET`
- wire Cloud Function to receive secret and read via `value()`
- read `x-webhook-secret` header via `req.get`
- update tests to inject secret stub

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bcf9512c0832580831c3d122075fa