### PR TITLE
Clarify Windows packaging path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The `electron-app` directory provides a small Electron application that listens 
 2. `npm install`
 3. `npm run package-win`
 
-The Windows executable will be created under electron-app/dist/lead-notifier-win32-x64/lead-notifier.exe for sharing.
+After running `npm run package-win`, the executable is located at `dist/lead-notifier-win32-x64/lead-notifier.exe` within the `electron-app` directory.
 
 
 ## Environment Variables


### PR DESCRIPTION
## Summary
- Clarify location of the packaged Windows executable for the Electron app

## Testing
- `npm test` (fails: could not read package.json)
- `cd electron-app && npm test`
- `cd functions && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cb9f1ed688325ac2f9631edbf6433