### PR TITLE
Replace functions index.js with CommonJS sample

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,57 +1,7 @@
-// Cloud Function for receiving email leads
-const { onRequest } = require("firebase-functions/v2/https");
-const admin = require("firebase-admin");
-const {
-  parseAdfEmail,
-  extractLeadFromContact,
-} = require("./adfEmailHandler");
+const { onRequest } = require('firebase-functions/v2/https');
+const logger = require('firebase-functions/logger');
 
-const gmailWebhookSecret = process.env.GMAIL_WEBHOOK_SECRET;
-
-admin.initializeApp();
-
-const receiveEmailLeadHandler = async (req, res) => {
-  try {
-    const secret = req.headers["x-webhook-secret"];
-    if (!secret || secret !== gmailWebhookSecret) {
-      return res.status(401).send("Unauthorized");
-    }
-
-    if (typeof req.body !== "string") {
-      return res.status(400).send("Body must be a string");
-    }
-
-    const bodyText = req.body.trim();
-    if (!bodyText) {
-      return res.status(400).send("Body cannot be empty");
-    }
-
-    const contentType = req.get("content-type") || null;
-    const doc = {
-      raw: bodyText,
-      receivedAt: admin.firestore.FieldValue.serverTimestamp(),
-      source: "gmail-webhook",
-      headers: { contentType },
-    };
-
-    const adf = parseAdfEmail(bodyText);
-    if (adf?.prospect?.customer?.contact) {
-      const lead = extractLeadFromContact(adf.prospect.customer.contact);
-      Object.assign(doc, lead);
-    }
-
-    try {
-      await admin.firestore().collection("leads_v2").add(doc);
-      return res.status(200).send("OK");
-    } catch (error) {
-      console.error("Firestore write failed:", error);
-      return res.status(500).send("Internal error");
-    }
-  } catch (err) {
-    console.error("Error handling email lead:", err);
-    return res.status(500).send("Internal error");
-  }
-};
-
-exports.receiveEmailLead = onRequest(receiveEmailLeadHandler);
-
+exports.helloWorld = onRequest((request, response) => {
+  logger.info('Hello logs!', { structuredData: true });
+  response.send('Hello from Firebase!');
+});


### PR DESCRIPTION
## Summary
- replace Firebase function with CommonJS sample using `onRequest`

## Testing
- `npm test` (fails: TypeError: receiveEmailLead is not a function)
- `firebase deploy` (fails: Error: Failed to authenticate, have you run firebase login?)

------
https://chatgpt.com/codex/tasks/task_e_689ccc40d14883259747a974200784ca