### PR TITLE
refactor: isolate firebase client env

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ The Cloud Function expects the following secrets, which should be set using `fir
 
 ### Electron App (`electron-app/`)
 
-The Electron app uses a `.env` file for Firebase and OpenAI configuration. Copy [`electron-app/.env.example`](electron-app/.env.example) to `electron-app/.env` and populate the following keys:
+The Electron app uses a `.env` file for Firebase and OpenAI configuration. Copy [`electron-app/.env.example`](electron-app/.env.example) to `electron-app/.env` and populate the following keys. Keep this file in the `electron-app/` directory so that only the Electron runtime reads these values:
 
-- `FIREBASE_API_KEY` – Firebase web API key.
-- `FIREBASE_AUTH_DOMAIN` – Firebase authentication domain.
-- `FIREBASE_PROJECT_ID` – Firebase project identifier.
-- `FIREBASE_STORAGE_BUCKET` – Firebase storage bucket name.
-- `FIREBASE_MESSAGING_SENDER_ID` – Firebase messaging sender ID.
-- `FIREBASE_APP_ID` – Firebase application ID.
+- `APP_FIREBASE_API_KEY` – Firebase web API key.
+- `APP_FIREBASE_AUTH_DOMAIN` – Firebase authentication domain.
+- `APP_FIREBASE_PROJECT_ID` – Firebase project identifier.
+- `APP_FIREBASE_STORAGE_BUCKET` – Firebase storage bucket name.
+- `APP_FIREBASE_MESSAGING_SENDER_ID` – Firebase messaging sender ID.
+- `APP_FIREBASE_APP_ID` – Firebase application ID.
 - `OPENAI_API_KEY` – API key for OpenAI features.
 

--- a/electron-app/.env.example
+++ b/electron-app/.env.example
@@ -1,7 +1,7 @@
-FIREBASE_API_KEY=your_firebase_api_key
-FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com
-FIREBASE_PROJECT_ID=your_project_id
-FIREBASE_STORAGE_BUCKET=your_project.appspot.com
-FIREBASE_MESSAGING_SENDER_ID=your_sender_id
-FIREBASE_APP_ID=your_app_id
+APP_FIREBASE_API_KEY=your_firebase_api_key
+APP_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com
+APP_FIREBASE_PROJECT_ID=your_project_id
+APP_FIREBASE_STORAGE_BUCKET=your_project.appspot.com
+APP_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
+APP_FIREBASE_APP_ID=your_app_id
 OPENAI_API_KEY=your_openai_api_key

--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -9,16 +9,16 @@ const {
 } = require('electron');
 const OpenAI = require('openai');
 const path = require('path');
-require('dotenv').config(); // ✅ Load .env for Firebase keys
+require('dotenv').config({ path: path.join(__dirname, '.env') }); // ✅ Load .env for Firebase keys
 
 // Ensure required environment variables are present
 const REQUIRED_ENV_VARS = [
-  'FIREBASE_API_KEY',
-  'FIREBASE_AUTH_DOMAIN',
-  'FIREBASE_PROJECT_ID',
-  'FIREBASE_STORAGE_BUCKET',
-  'FIREBASE_MESSAGING_SENDER_ID',
-  'FIREBASE_APP_ID',
+  'APP_FIREBASE_API_KEY',
+  'APP_FIREBASE_AUTH_DOMAIN',
+  'APP_FIREBASE_PROJECT_ID',
+  'APP_FIREBASE_STORAGE_BUCKET',
+  'APP_FIREBASE_MESSAGING_SENDER_ID',
+  'APP_FIREBASE_APP_ID',
   'OPENAI_API_KEY',
 ];
 

--- a/electron-app/renderer.js
+++ b/electron-app/renderer.js
@@ -9,12 +9,12 @@ import {
 
 // Firebase config
 const firebaseConfig = {
-  apiKey: window.electronAPI.getEnv('FIREBASE_API_KEY'),
-  authDomain: window.electronAPI.getEnv('FIREBASE_AUTH_DOMAIN'),
-  projectId: window.electronAPI.getEnv('FIREBASE_PROJECT_ID'),
-  storageBucket: window.electronAPI.getEnv('FIREBASE_STORAGE_BUCKET'),
-  messagingSenderId: window.electronAPI.getEnv('FIREBASE_MESSAGING_SENDER_ID'),
-  appId: window.electronAPI.getEnv('FIREBASE_APP_ID'),
+  apiKey: window.electronAPI.getEnv('APP_FIREBASE_API_KEY'),
+  authDomain: window.electronAPI.getEnv('APP_FIREBASE_AUTH_DOMAIN'),
+  projectId: window.electronAPI.getEnv('APP_FIREBASE_PROJECT_ID'),
+  storageBucket: window.electronAPI.getEnv('APP_FIREBASE_STORAGE_BUCKET'),
+  messagingSenderId: window.electronAPI.getEnv('APP_FIREBASE_MESSAGING_SENDER_ID'),
+  appId: window.electronAPI.getEnv('APP_FIREBASE_APP_ID'),
 };
 
 // Init Firebase


### PR DESCRIPTION
## Summary
- prefix Firebase client env vars with `APP_`
- load `electron-app/.env` directly and remove root exposure
- document new env names for Electron app

## Testing
- `cd electron-app && npm test`
- `cd functions && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cd2d6e160832582c140cd8beb2265