### PR TITLE
Adopt snake_case for lead fields

### DIFF
--- a/electron-app/renderer.js
+++ b/electron-app/renderer.js
@@ -98,15 +98,16 @@ const notifyUser = (title, body) => {
 };
 
 const logLeadToUI = (lead) => {
+  const { first_name, last_name, phone, email, vehicle, trade, comments } = lead;
   const div = document.createElement("div");
   div.className = "lead-entry";
   div.innerHTML = `
-    <h3>${lead.first_name} ${lead.last_name}</h3>
-    <p><strong>Phone:</strong> ${lead.phone}</p>
-    <p><strong>Email:</strong> ${lead.email}</p>
-    <p><strong>Vehicle:</strong> ${lead.vehicle}</p>
-    <p><strong>Trade:</strong> ${lead.trade}</p>
-    <p><strong>Comments:</strong> ${lead.comments || "None"}</p>
+    <h3>${first_name} ${last_name}</h3>
+    <p><strong>Phone:</strong> ${phone}</p>
+    <p><strong>Email:</strong> ${email}</p>
+    <p><strong>Vehicle:</strong> ${vehicle}</p>
+    <p><strong>Trade:</strong> ${trade}</p>
+    <p><strong>Comments:</strong> ${comments || "None"}</p>
     <hr />
   `;
   leadLog.prepend(div);

--- a/functions/adfEmailHandler.js
+++ b/functions/adfEmailHandler.js
@@ -74,16 +74,16 @@ function extractLeadFromContact(contact = {}) {
   const firstObj = nameEntries.find((n) => n?.["@_part"] === "first");
   const lastObj = nameEntries.find((n) => n?.["@_part"] === "last");
 
-  const firstName = getText(firstObj);
-  const lastName = getText(lastObj);
+  const first_name = getText(firstObj);
+  const last_name = getText(lastObj);
 
   // Extract phone and email text content, falling back to string values
   const phone = getText(contact.phone);
   const email = getText(contact.email);
 
   return {
-    firstName,
-    lastName,
+    first_name,
+    last_name,
     phone,
     email,
   };

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,7 +1,37 @@
 const { onRequest } = require('firebase-functions/v2/https');
 const logger = require('firebase-functions/logger');
+const admin = require('firebase-admin');
+const { parseAdfEmail, extractLeadFromContact } = require('./adfEmailHandler');
+
+admin.initializeApp();
 
 exports.helloWorld = onRequest((request, response) => {
   logger.info('Hello logs!', { structuredData: true });
   response.send('Hello from Firebase!');
 });
+
+exports.receiveEmailLead = async (req, res) => {
+  const secret = req.headers['x-webhook-secret'];
+  if (!secret || secret !== process.env.GMAIL_WEBHOOK_SECRET) {
+    return res.status(401).send('Unauthorized');
+  }
+
+  const body = req.body;
+  if (typeof body !== 'string' || body.trim() === '') {
+    return res.status(400).send('Invalid body');
+  }
+
+  const adf = parseAdfEmail(body);
+  let lead = {};
+  const contact = adf?.prospect?.customer?.contact;
+  if (contact) {
+    lead = extractLeadFromContact(contact);
+  }
+
+  await admin.firestore().collection('leads_v2').add({
+    ...lead,
+    receivedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+
+  res.status(200).send('OK');
+};

--- a/functions/test/adf-parsing.test.js
+++ b/functions/test/adf-parsing.test.js
@@ -41,16 +41,16 @@ const run = async (body) => {
 
   const successStatus = await run(validAdf);
   assert.strictEqual(successStatus, 200, 'should accept valid ADF body');
-  assert.strictEqual(addedDoc.firstName, 'Jane');
-  assert.strictEqual(addedDoc.lastName, 'Doe');
+  assert.strictEqual(addedDoc.first_name, 'Jane');
+  assert.strictEqual(addedDoc.last_name, 'Doe');
   assert.strictEqual(addedDoc.phone, '555-1234');
   assert.strictEqual(addedDoc.email, 'jane@example.com');
 
   const fallbackStatus = await run('Just some text');
   assert.strictEqual(fallbackStatus, 200, 'should accept plain text');
   assert.ok(addedDoc, 'document should be written');
-  assert.strictEqual(addedDoc.firstName, undefined);
-  assert.strictEqual(addedDoc.lastName, undefined);
+  assert.strictEqual(addedDoc.first_name, undefined);
+  assert.strictEqual(addedDoc.last_name, undefined);
   assert.strictEqual(addedDoc.phone, undefined);
   assert.strictEqual(addedDoc.email, undefined);
 


### PR DESCRIPTION
## Summary
- normalize lead parsing to snake_case
- store and log leads using snake_case fields
- adjust renderer UI logging for new field casing

## Testing
- `cd functions && npm test`
- `cd ../electron-app && npm test`
- `cd functions && node -e "/* sample lead script */"`

------
https://chatgpt.com/codex/tasks/task_e_689cee912d3c8325ae7939ddb71df5e8