### PR TITLE
feat: add express app with secret-bound email webhook

### DIFF
--- a/functions/test/adf-parsing.test.js
+++ b/functions/test/adf-parsing.test.js
@@ -16,7 +16,7 @@ adminStub.firestore.FieldValue = { serverTimestamp: () => 'ts' };
 require.cache[require.resolve('firebase-admin')] = { exports: adminStub };
 
 process.env.GMAIL_WEBHOOK_SECRET = 'expected-secret';
-const { receiveEmailLead } = require('../index.js');
+const { receiveEmailLeadHandler } = require('../index.js');
 
 const run = async (body) => {
   let statusCode;
@@ -32,7 +32,7 @@ const run = async (body) => {
       return { send: () => {} };
     },
   };
-  await receiveEmailLead(req, res);
+  await receiveEmailLeadHandler(req, res);
   return statusCode;
 };
 

--- a/functions/test/body-validation.test.js
+++ b/functions/test/body-validation.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 
 process.env.GMAIL_WEBHOOK_SECRET = 'expected-secret';
-const { receiveEmailLead } = require('../index.js');
+const { receiveEmailLeadHandler } = require('../index.js');
 
 const run = async (body) => {
   let statusCode;
@@ -16,7 +16,7 @@ const run = async (body) => {
       return { send: () => {} };
     },
   };
-  await receiveEmailLead(req, res);
+  await receiveEmailLeadHandler(req, res);
   return statusCode;
 };
 

--- a/functions/test/webhook-secret.test.js
+++ b/functions/test/webhook-secret.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 
 process.env.GMAIL_WEBHOOK_SECRET = 'expected-secret';
-const { receiveEmailLead } = require('../index.js');
+const { receiveEmailLeadHandler } = require('../index.js');
 
 const run = async (headers) => {
   let statusCode;
@@ -11,7 +11,7 @@ const run = async (headers) => {
       return { send: () => {} };
     },
   };
-  await receiveEmailLead({ headers }, res);
+  await receiveEmailLeadHandler({ headers, body: '', get: () => null }, res);
   return statusCode;
 };
 


### PR DESCRIPTION
## Summary
- use firebase-functions/params to define GMAIL_WEBHOOK_SECRET and OPENAI_API_KEY
- migrate email webhook to an Express app with 1MB text body parsing
- export function bound to region and secrets and expose handler for tests

## Testing
- `cd functions && npm test`
- `cd electron-app && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d121744608325b5bbb029c2df3882