### PR TITLE
Add Cloud Function for AI replies and IPC tests

### DIFF
--- a/electron-app/.env.example
+++ b/electron-app/.env.example
@@ -1,3 +1,4 @@
+## Environment variables required for the Electron app
 APP_FIREBASE_API_KEY=your_firebase_api_key
 APP_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com
 APP_FIREBASE_PROJECT_ID=your_project_id

--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -31,6 +31,7 @@ let tray = null;
 let win;
 
 ipcMain.handle('request-ai-reply', async (_event, lead) => {
+  // Forward lead data to Cloud Function that uses server-side OpenAI secret
   const url = `https://us-central1-${process.env.APP_FIREBASE_PROJECT_ID}.cloudfunctions.net/generateAIReply`;
 
   try {

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "test": "node test/smoke.test.js",
+    "test": "node test/smoke.test.js && node test/ipc-handler.test.js",
     "package-win": "npx @electron/packager . lead-notifier --platform=win32 --arch=x64 --out=dist --overwrite --icon=icon.png"
   },
   "author": "Rob Brasco",

--- a/electron-app/test/ipc-handler.test.js
+++ b/electron-app/test/ipc-handler.test.js
@@ -1,0 +1,59 @@
+const assert = require('assert');
+
+// Stub Electron modules to capture IPC handler
+let registeredHandler;
+const ipcMainStub = {
+  handle: (channel, handler) => {
+    if (channel === 'request-ai-reply') {
+      registeredHandler = handler;
+    }
+  },
+};
+const electronStub = {
+  ipcMain: ipcMainStub,
+  app: {
+    whenReady: () => Promise.resolve(),
+    setLoginItemSettings: () => {},
+    on: () => {},
+  },
+  BrowserWindow: function () {
+    return { loadFile: () => {}, webContents: {}, on: () => {} };
+  },
+  Tray: function () {
+    this.setToolTip = () => {};
+    this.setContextMenu = () => {};
+    this.on = () => {};
+  },
+  Menu: { buildFromTemplate: () => ({}) },
+  nativeImage: { createFromPath: () => ({ isEmpty: () => true }) },
+};
+require.cache[require.resolve('electron')] = { exports: electronStub };
+
+process.env.APP_FIREBASE_API_KEY = 'x';
+process.env.APP_FIREBASE_AUTH_DOMAIN = 'x';
+process.env.APP_FIREBASE_PROJECT_ID = 'proj';
+process.env.APP_FIREBASE_STORAGE_BUCKET = 'x';
+process.env.APP_FIREBASE_MESSAGING_SENDER_ID = 'x';
+process.env.APP_FIREBASE_APP_ID = 'x';
+
+let fetchArgs;
+global.fetch = async (url, options) => {
+  fetchArgs = { url, options };
+  return { ok: true, json: async () => ({ reply: 'Hi there' }) };
+};
+
+// Require main.js after stubbing
+require('../main.js');
+
+(async () => {
+  const lead = { comments: 'Interested' };
+  const result = await registeredHandler(null, lead);
+  assert.strictEqual(
+    fetchArgs.url,
+    'https://us-central1-proj.cloudfunctions.net/generateAIReply'
+  );
+  assert.strictEqual(fetchArgs.options.method, 'POST');
+  assert.deepStrictEqual(JSON.parse(fetchArgs.options.body), lead);
+  assert.strictEqual(result, 'Hi there');
+  console.log('IPC handler test passed');
+})();

--- a/functions/index.js
+++ b/functions/index.js
@@ -83,6 +83,8 @@ const generateAIReplyHandler = async (req, res) => {
 
 aiApp.post('/', generateAIReplyHandler);
 
+exports.generateAIReplyHandler = generateAIReplyHandler;
+
 exports.generateAIReply = onRequest(
   { region: 'us-central1', secrets: [OPENAI_API_KEY] },
   aiApp

--- a/functions/package.json
+++ b/functions/package.json
@@ -3,7 +3,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "test": "node test/smoke.test.js && node test/webhook-secret.test.js && node test/body-validation.test.js && node test/adf-parsing.test.js"
+    "test": "node test/smoke.test.js && node test/webhook-secret.test.js && node test/body-validation.test.js && node test/adf-parsing.test.js && node test/generate-ai-reply.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/functions/test/generate-ai-reply.test.js
+++ b/functions/test/generate-ai-reply.test.js
@@ -1,0 +1,41 @@
+const assert = require('assert');
+
+// Stub OpenAI to avoid network calls and capture usage
+let constructorKey;
+let capturedPrompt;
+class OpenAIStub {
+  constructor(opts) {
+    constructorKey = opts.apiKey;
+  }
+  chat = {
+    completions: {
+      create: async (opts) => {
+        capturedPrompt = opts.messages[0].content;
+        return { choices: [{ message: { content: 'Test reply' } }] };
+      },
+    },
+  };
+}
+require.cache[require.resolve('openai')] = { exports: OpenAIStub };
+
+process.env.OPENAI_API_KEY = 'server-secret';
+const { generateAIReplyHandler } = require('../index.js');
+
+(async () => {
+  let jsonResponse;
+  const req = { body: { comments: 'Hello' } };
+  const res = {
+    json: (data) => {
+      jsonResponse = data;
+    },
+    status: (code) => ({ send: () => { throw new Error('Unexpected error ' + code); } }),
+  };
+
+  await generateAIReplyHandler(req, res);
+
+  assert.strictEqual(constructorKey, 'server-secret', 'should use server-side API key');
+  assert.ok(capturedPrompt.includes('Hello'), 'prompt should include lead comments');
+  assert.deepStrictEqual(jsonResponse, { reply: 'Test reply' });
+
+  console.log('generateAIReply tests passed');
+})();


### PR DESCRIPTION
## Summary
- expose new `generateAIReplyHandler` Cloud Function that calls OpenAI using a server-side secret
- invoke Cloud Function from Electron via IPC and remove client-side OpenAI dependency
- add tests covering the Cloud Function and the IPC handler

## Testing
- `cd functions && npm test`
- `cd electron-app && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d4077f47c83258c1c6b264397f053