### PR TITLE
Restrict preload env access

### DIFF
--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "test": "node test/smoke.test.js",
+    "test": "node test/smoke.test.js && node test/preload.test.js",
     "package-win": "npx @electron/packager . lead-notifier --platform=win32 --arch=x64 --out=dist --overwrite --icon=icon.png"
   },
   "author": "Rob Brasco",

--- a/electron-app/preload.js
+++ b/electron-app/preload.js
@@ -2,7 +2,24 @@
 
 const { contextBridge, ipcRenderer } = require('electron');
 
+// Only expose explicitly allowed environment variables to the renderer
+const ALLOWED_ENV_KEYS = new Set([
+  'APP_FIREBASE_API_KEY',
+  'APP_FIREBASE_AUTH_DOMAIN',
+  'APP_FIREBASE_PROJECT_ID',
+  'APP_FIREBASE_STORAGE_BUCKET',
+  'APP_FIREBASE_MESSAGING_SENDER_ID',
+  'APP_FIREBASE_APP_ID',
+]);
+
+const getEnv = (key) => {
+  if (ALLOWED_ENV_KEYS.has(key)) {
+    return process.env[key] || null;
+  }
+  return null;
+};
+
 contextBridge.exposeInMainWorld('electronAPI', {
-  getEnv: (key) => process.env[key] || null,
+  getEnv,
   requestAIReply: (lead) => ipcRenderer.invoke('request-ai-reply', lead),
 });

--- a/electron-app/test/preload.test.js
+++ b/electron-app/test/preload.test.js
@@ -1,0 +1,46 @@
+const assert = require('assert');
+const Module = require('module');
+
+// Stub the electron module to capture the exposed API
+let exposedApi;
+const electronMock = {
+  contextBridge: {
+    exposeInMainWorld: (_name, api) => {
+      exposedApi = api;
+    },
+  },
+  ipcRenderer: {
+    invoke: () => {},
+  },
+};
+
+const originalLoad = Module._load;
+Module._load = function(request, parent, isMain) {
+  if (request === 'electron') {
+    return electronMock;
+  }
+  return originalLoad(request, parent, isMain);
+};
+
+// Set up environment variables
+process.env.APP_FIREBASE_API_KEY = 'allowed-value';
+process.env.SECRET_API_KEY = 'top-secret';
+
+// Require the preload script which will populate exposedApi
+require('../preload.js');
+
+// Restore original Module loader
+Module._load = originalLoad;
+
+assert.strictEqual(
+  exposedApi.getEnv('APP_FIREBASE_API_KEY'),
+  'allowed-value',
+  'Allowed env vars should return their value'
+);
+assert.strictEqual(
+  exposedApi.getEnv('SECRET_API_KEY'),
+  null,
+  'Disallowed env vars should return null'
+);
+
+console.log('preload.js getEnv tests passed');


### PR DESCRIPTION
## Summary
- Limit `getEnv` to a fixed allow-list of Firebase-related keys
- Add tests confirming disallowed env keys return `null`
- Update test script to run preload env tests

## Testing
- `cd electron-app && npm test`
- `cd functions && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d4078a8b4832593ec21ab1290f85d