### PR TITLE
Validate ADF parsing before storing leads

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -32,6 +32,10 @@ const receiveEmailLeadHandler = async (req, res) => {
   }
 
   const adf = parseAdfEmail(body);
+  if (!adf) {
+    return res.status(400).send('Invalid ADF body');
+  }
+
   let lead = {};
   const contact = adf?.prospect?.customer?.contact;
   if (contact) {

--- a/functions/test/adf-parsing.test.js
+++ b/functions/test/adf-parsing.test.js
@@ -46,13 +46,9 @@ const run = async (body) => {
   assert.strictEqual(addedDoc.phone, '555-1234');
   assert.strictEqual(addedDoc.email, 'jane@example.com');
 
-  const fallbackStatus = await run('Just some text');
-  assert.strictEqual(fallbackStatus, 200, 'should accept plain text');
-  assert.ok(addedDoc, 'document should be written');
-  assert.strictEqual(addedDoc.first_name, undefined);
-  assert.strictEqual(addedDoc.last_name, undefined);
-  assert.strictEqual(addedDoc.phone, undefined);
-  assert.strictEqual(addedDoc.email, undefined);
+  const malformedStatus = await run('Just some text');
+  assert.strictEqual(malformedStatus, 400, 'should reject malformed body');
+  assert.strictEqual(addedDoc, null, 'document should not be written');
 
   console.log('ADF parsing tests passed');
 })();


### PR DESCRIPTION
## Summary
- return 400 when ADF parsing fails and skip Firestore write
- test valid ADF bodies are stored and malformed bodies are rejected

## Testing
- `cd functions && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d407610108325ab0cc3535d9debcc