### PR TITLE
test: include ipc handler test in suite

### DIFF
--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "test": "node test/smoke.test.js",
+    "test": "node test/smoke.test.js && node test/ipc-handler.test.js && node test/preload.test.js",
     "package-win": "npx @electron/packager . lead-notifier --platform=win32 --arch=x64 --out=dist --overwrite --icon=icon.png"
   },
   "author": "Rob Brasco",

--- a/electron-app/preload.js
+++ b/electron-app/preload.js
@@ -2,7 +2,25 @@
 
 const { contextBridge, ipcRenderer } = require('electron');
 
+// Only expose explicitly allowed Firebase config variables to the renderer.
+// Any key not in this list returns null to prevent leaking secrets.
+const ALLOWED_ENV_KEYS = new Set([
+  'APP_FIREBASE_API_KEY',
+  'APP_FIREBASE_AUTH_DOMAIN',
+  'APP_FIREBASE_PROJECT_ID',
+  'APP_FIREBASE_STORAGE_BUCKET',
+  'APP_FIREBASE_MESSAGING_SENDER_ID',
+  'APP_FIREBASE_APP_ID',
+]);
+
+const getEnv = (key) => {
+  if (ALLOWED_ENV_KEYS.has(key)) {
+    return process.env[key] || null;
+  }
+  return null;
+};
+
 contextBridge.exposeInMainWorld('electronAPI', {
-  getEnv: (key) => process.env[key] || null,
+  getEnv,
   requestAIReply: (lead) => ipcRenderer.invoke('request-ai-reply', lead),
 });

--- a/electron-app/test/ipc-handler.test.js
+++ b/electron-app/test/ipc-handler.test.js
@@ -1,0 +1,80 @@
+const assert = require('assert');
+
+// Backup global state before modification
+const originalFetch = global.fetch;
+const originalElectronCache = require.cache[require.resolve('electron')];
+const originalEnv = { ...process.env };
+
+// Stub Electron modules to capture IPC handler
+let registeredHandler;
+const ipcMainStub = {
+  handle: (channel, handler) => {
+    if (channel === 'request-ai-reply') {
+      registeredHandler = handler;
+    }
+  },
+};
+const electronStub = {
+  ipcMain: ipcMainStub,
+  app: {
+    whenReady: () => Promise.resolve(),
+    setLoginItemSettings: () => {},
+    on: () => {},
+  },
+  BrowserWindow: function () {
+    return { loadFile: () => {}, webContents: {}, on: () => {} };
+  },
+  Tray: function () {
+    this.setToolTip = () => {};
+    this.setContextMenu = () => {};
+    this.on = () => {};
+  },
+  Menu: { buildFromTemplate: () => ({}) },
+  nativeImage: { createFromPath: () => ({ isEmpty: () => true }) },
+};
+require.cache[require.resolve('electron')] = { exports: electronStub };
+
+process.env.APP_FIREBASE_API_KEY = 'x';
+process.env.APP_FIREBASE_AUTH_DOMAIN = 'x';
+process.env.APP_FIREBASE_PROJECT_ID = 'proj';
+process.env.APP_FIREBASE_STORAGE_BUCKET = 'x';
+process.env.APP_FIREBASE_MESSAGING_SENDER_ID = 'x';
+process.env.APP_FIREBASE_APP_ID = 'x';
+
+let fetchArgs;
+global.fetch = async (url, options) => {
+  fetchArgs = { url, options };
+  return { ok: true, json: async () => ({ reply: 'Hi there' }) };
+};
+
+// Require main.js after stubbing
+require('../main.js');
+
+(async () => {
+  try {
+    const lead = { comments: 'Interested' };
+    const result = await registeredHandler(null, lead);
+    assert.strictEqual(
+      fetchArgs.url,
+      'https://us-central1-proj.cloudfunctions.net/generateAIReply'
+    );
+    assert.strictEqual(fetchArgs.options.method, 'POST');
+    assert.deepStrictEqual(JSON.parse(fetchArgs.options.body), lead);
+    assert.strictEqual(result, 'Hi there');
+    console.log('IPC handler test passed');
+  } finally {
+    // Restore global state
+    global.fetch = originalFetch;
+    if (originalElectronCache) {
+      require.cache[require.resolve('electron')] = originalElectronCache;
+    } else {
+      delete require.cache[require.resolve('electron')];
+    }
+    Object.keys(process.env).forEach((key) => {
+      if (!Object.prototype.hasOwnProperty.call(originalEnv, key)) {
+        delete process.env[key];
+      }
+    });
+    Object.assign(process.env, originalEnv);
+  }
+})();

--- a/electron-app/test/preload.test.js
+++ b/electron-app/test/preload.test.js
@@ -1,0 +1,60 @@
+const assert = require('assert');
+const Module = require('module');
+
+// Backup globals
+const originalLoad = Module._load;
+const originalEnv = { ...process.env };
+
+// Stub the electron module to capture the exposed API
+let exposedApi;
+const electronMock = {
+  contextBridge: {
+    exposeInMainWorld: (_name, api) => {
+      exposedApi = api;
+    },
+  },
+  ipcRenderer: {
+    invoke: () => {},
+  },
+};
+
+try {
+  Module._load = function (request, parent, isMain) {
+    if (request === 'electron') {
+      return electronMock;
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  // Set up environment variables
+  process.env.APP_FIREBASE_API_KEY = 'allowed-value';
+  process.env.SECRET_API_KEY = 'top-secret';
+
+  // Require the preload script which will populate exposedApi
+  const preloadPath = require.resolve('../preload.js');
+  require(preloadPath);
+
+  assert.strictEqual(
+    exposedApi.getEnv('APP_FIREBASE_API_KEY'),
+    'allowed-value',
+    'Allowed env vars should return their value'
+  );
+  assert.strictEqual(
+    exposedApi.getEnv('SECRET_API_KEY'),
+    null,
+    'Disallowed env vars should return null'
+  );
+
+  console.log('preload.js getEnv tests passed');
+} finally {
+  // Restore original Module loader and environment
+  Module._load = originalLoad;
+  const preloadPath = require.resolve('../preload.js');
+  delete require.cache[preloadPath];
+  Object.keys(process.env).forEach((key) => {
+    if (!Object.prototype.hasOwnProperty.call(originalEnv, key)) {
+      delete process.env[key];
+    }
+  });
+  Object.assign(process.env, originalEnv);
+}


### PR DESCRIPTION
## Summary
- expose only whitelisted Firebase config vars via `getEnv`
- add preload test verifying whitelisting and disallowed env vars returning null
- include IPC handler and preload tests in npm test script

## Testing
- `cd electron-app && npm install`
- `cd electron-app && npm test`
- `cd functions && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d4078a8b4832593ec21ab1290f85d