### PR TITLE
chore: run oversized body test in npm script

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -3,7 +3,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "test": "node test/smoke.test.js && node test/webhook-secret.test.js && node test/body-validation.test.js && node test/adf-parsing.test.js && node test/generate-ai-reply.test.js"
+    "test": "node test/smoke.test.js && node test/webhook-secret.test.js && node test/body-validation.test.js && node test/adf-parsing.test.js && node test/generate-ai-reply.test.js && node test/oversized-body.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- include oversized body test in npm test script

## Testing
- `npm install`
- `npm test` *(fails: Cannot find module '/workspace/Priority-Lead-Sync/functions/test/oversized-body.test.js')*

------
https://chatgpt.com/codex/tasks/task_e_689e110e816c8325ae5d60bcdca891aa