### PR TITLE
Add comprehensive tests for AI reply endpoint

### DIFF
--- a/functions/test/generate-ai-reply.test.js
+++ b/functions/test/generate-ai-reply.test.js
@@ -21,21 +21,42 @@ require.cache[require.resolve('openai')] = { exports: OpenAIStub };
 process.env.OPENAI_API_KEY = 'server-secret';
 const { generateAIReplyHandler } = require('../index.js');
 
-(async () => {
+const run = async (body) => {
+  constructorKey = undefined;
+  capturedPrompt = undefined;
+  let statusCode;
   let jsonResponse;
-  const req = { body: { comments: 'Hello' } };
+  const req = { body };
   const res = {
     json: (data) => {
       jsonResponse = data;
     },
-    status: (code) => ({ send: () => { throw new Error('Unexpected error ' + code); } }),
+    status: (code) => {
+      statusCode = code;
+      return { send: () => {} };
+    },
   };
-
   await generateAIReplyHandler(req, res);
+  return { statusCode, jsonResponse };
+};
 
+(async () => {
+  // With comments
+  const withComments = await run({ comments: 'Hello' });
   assert.strictEqual(constructorKey, 'server-secret', 'should use server-side API key');
   assert.ok(capturedPrompt.includes('Hello'), 'prompt should include lead comments');
-  assert.deepStrictEqual(jsonResponse, { reply: 'Test reply' });
+  assert.deepStrictEqual(withComments.jsonResponse, { reply: 'Test reply' });
+
+  // Without comments but with vehicle
+  const noComments = await run({ vehicle: 'RX 350' });
+  assert.ok(capturedPrompt.includes('RX 350'), 'prompt should mention vehicle when no comments');
+  assert.deepStrictEqual(noComments.jsonResponse, { reply: 'Test reply' });
+
+  // Invalid body
+  const invalid = await run(null);
+  assert.strictEqual(invalid.statusCode, 400, 'should reject malformed body');
+  assert.strictEqual(invalid.jsonResponse, undefined, 'should not return JSON on error');
+  assert.strictEqual(capturedPrompt, undefined, 'should not call OpenAI for invalid body');
 
   console.log('generateAIReply tests passed');
 })();


### PR DESCRIPTION
## Summary
- extend generateAIReply tests to cover comment, vehicle, and invalid payload scenarios
- ensure OpenAI stub captures prompts and verifies API key usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e1111a64c8325a3bd5eaf0a3bcfea