### PR TITLE
test: add Supertest for AI reply

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -11,7 +11,8 @@
         "fast-xml-parser": "^5.2.5",
         "firebase-admin": "^12.0.0",
         "firebase-functions": "^4.0.0",
-        "openai": "^4.104.0"
+        "openai": "^4.104.0",
+        "supertest": "^6.3.3"
       },
       "engines": {
         "node": ">=18"
@@ -272,6 +273,18 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -280,6 +293,15 @@
       "optional": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -627,6 +649,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "license": "MIT"
+    },
     "node_modules/async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -789,6 +817,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -823,6 +860,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -879,6 +922,16 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dunder-proto": {
@@ -1097,6 +1150,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "license": "MIT"
+    },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
@@ -1252,6 +1311,21 @@
       },
       "engines": {
         "node": ">= 12.20"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
+      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -2103,7 +2177,6 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2588,6 +2661,93 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
+      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "deprecated": "Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.1.2"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
+    },
     "node_modules/teeny-request": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
@@ -2828,8 +2988,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/functions/package.json
+++ b/functions/package.json
@@ -12,6 +12,7 @@
     "fast-xml-parser": "^5.2.5",
     "firebase-admin": "^12.0.0",
     "firebase-functions": "^4.0.0",
-    "openai": "^4.104.0"
+    "openai": "^4.104.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/functions/test/generate-ai-reply.test.js
+++ b/functions/test/generate-ai-reply.test.js
@@ -1,4 +1,9 @@
 const assert = require('assert');
+const request = require('supertest');
+const express = require('express');
+
+// Set dummy server-side API key before loading the handler
+process.env.OPENAI_API_KEY = 'server-secret';
 
 // Stub OpenAI to avoid network calls and capture usage
 let constructorKey;
@@ -9,8 +14,8 @@ class OpenAIStub {
   }
   chat = {
     completions: {
-      create: async (opts) => {
-        capturedPrompt = opts.messages[0].content;
+      create: async ({ messages }) => {
+        capturedPrompt = messages[0].content;
         return { choices: [{ message: { content: 'Test reply' } }] };
       },
     },
@@ -18,24 +23,61 @@ class OpenAIStub {
 }
 require.cache[require.resolve('openai')] = { exports: OpenAIStub };
 
-process.env.OPENAI_API_KEY = 'server-secret';
 const { generateAIReplyHandler } = require('../index.js');
 
-(async () => {
+const run = async (body) => {
+  constructorKey = undefined;
+  capturedPrompt = undefined;
+  let statusCode;
   let jsonResponse;
-  const req = { body: { comments: 'Hello' } };
+  const req = { body };
   const res = {
     json: (data) => {
       jsonResponse = data;
     },
-    status: (code) => ({ send: () => { throw new Error('Unexpected error ' + code); } }),
+    status: (code) => {
+      statusCode = code;
+      return { send: () => {} };
+    },
   };
-
   await generateAIReplyHandler(req, res);
+  return { statusCode, jsonResponse };
+};
 
+(async () => {
+  // With comments
+  const withComments = await run({ comments: 'Hello' });
   assert.strictEqual(constructorKey, 'server-secret', 'should use server-side API key');
   assert.ok(capturedPrompt.includes('Hello'), 'prompt should include lead comments');
-  assert.deepStrictEqual(jsonResponse, { reply: 'Test reply' });
+  assert.deepStrictEqual(withComments.jsonResponse, { reply: 'Test reply' });
+
+  // Without comments but with vehicle
+  const noComments = await run({ vehicle: 'RX 350' });
+  assert.ok(capturedPrompt.includes('RX 350'), 'prompt should mention vehicle when no comments');
+  assert.deepStrictEqual(noComments.jsonResponse, { reply: 'Test reply' });
+
+  // Invalid body
+  const invalid = await run(null);
+  assert.strictEqual(invalid.statusCode, 400, 'should reject malformed body');
+  assert.strictEqual(invalid.jsonResponse, undefined, 'should not return JSON on error');
+  assert.strictEqual(capturedPrompt, undefined, 'should not call OpenAI for invalid body');
+
+  // Express route through Supertest
+  constructorKey = undefined;
+  capturedPrompt = undefined;
+  const app = express();
+  app.use(express.json());
+  app.post('/', generateAIReplyHandler);
+
+  const res = await request(app)
+    .post('/')
+    .send({ comments: 'Hello from lead' })
+    .expect(200);
+
+  assert.strictEqual(constructorKey, 'server-secret', 'should use server-side API key');
+  assert.ok(capturedPrompt.includes('Hello from lead'), 'prompt should include lead comments');
+  assert.deepStrictEqual(res.body, { reply: 'Test reply' });
 
   console.log('generateAIReply tests passed');
 })();
+


### PR DESCRIPTION
## Summary
- combine existing generateAIReply tests with new Supertest coverage
- ensure prompts, API key, and HTTP response behavior are validated

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e11932cec8325a8c79352e01d6114