### PR TITLE
Fix workflow YAML merge artifacts and quote Firestore step names

### DIFF
--- a/.github/workflows/ci-admin.yml
+++ b/.github/workflows/ci-admin.yml
@@ -40,11 +40,7 @@ jobs:
         env:
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
 
- codex/add-ci/cd-and-firebase-setup-details-emkg71
       - name: "Firestore sanity write (DB: leads)"
-
-      - name: Firestore sanity write (DB: leads)
- main
         run: node scripts/run-admin.cjs
         env:
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/pr-safety.yml
+++ b/.github/workflows/pr-safety.yml
@@ -25,11 +25,7 @@ jobs:
       - name: Install firebase-admin for sanity script
         run: npm i firebase-admin
 
- codex/add-ci/cd-and-firebase-setup-details-emkg71
       - name: "Firestore sanity (DB: leads)"
-
-      - name: Firestore sanity (DB: leads)
- main
         run: node scripts/run-admin.cjs
         env:
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
## Summary
- clean up stray merge text in CI admin deployment workflow
- clean up stray merge text in PR safety workflow
- ensure Firestore sanity steps use quoted names for YAML validity

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd functions && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e360c6828832587aec3b196838cf5