### PR TITLE
Add default Firebase hosting index

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Priority Lead Sync</title>
+</head>
+<body>
+  <h1>Priority Lead Sync</h1>
+  <p>Firebase Hosting Setup Complete.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a `public/index.html` page for Firebase Hosting

## Testing
- `npm test` *(fails: could not read package.json)*
- `npx firebase-tools deploy --only hosting`

------
https://chatgpt.com/codex/tasks/task_e_689e6831f97c8325a7bc30ce24c02e2f