### PR TITLE
feat(functions): add Gmail OAuth health check and tolerant lead parsing

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,18 +1,25 @@
+// functions/index.js (Gen 2 + Gmail OAuth + tolerant JSON/XML)
 import { onRequest } from "firebase-functions/v2/https";
 import { defineSecret } from "firebase-functions/params";
 import * as admin from "firebase-admin";
+import { google } from "googleapis";
 import { parseStringPromise } from "xml2js";
 
 try { admin.initializeApp(); } catch {}
 
-/** Runtime secrets (mounted via Google Secret Manager) */
+// Secrets (mounted via Google Secret Manager)
 const GMAIL_WEBHOOK_SECRET = defineSecret("GMAIL_WEBHOOK_SECRET");
 const OPENAI_API_KEY       = defineSecret("OPENAI_API_KEY");
 
-/** Health check */
+const GMAIL_CLIENT_ID     = defineSecret("GMAIL_CLIENT_ID");
+const GMAIL_CLIENT_SECRET = defineSecret("GMAIL_CLIENT_SECRET");
+const GMAIL_REFRESH_TOKEN = defineSecret("GMAIL_REFRESH_TOKEN");
+const GMAIL_REDIRECT_URI  = defineSecret("GMAIL_REDIRECT_URI");
+
+// --- health ---
 export const health = onRequest({ region: "us-central1" }, (_req, res) => res.status(200).send("ok"));
 
-/** Verify secrets are mounted (no values leaked) */
+// --- testSecrets ---
 export const testSecrets = onRequest(
   { region: "us-central1", secrets: [GMAIL_WEBHOOK_SECRET, OPENAI_API_KEY] },
   (_req, res) => {
@@ -27,13 +34,48 @@ export const testSecrets = onRequest(
   }
 );
 
-/** Primary webhook: auth via x-webhook-secret; accepts JSON or ADF/XML; writes to Firestore */
+// --- Gmail: build an authenticated client from refresh token ---
+function buildGmailClient() {
+  const oauth2 = new google.auth.OAuth2(
+    process.env.GMAIL_CLIENT_ID,
+    process.env.GMAIL_CLIENT_SECRET,
+    process.env.GMAIL_REDIRECT_URI
+  );
+  oauth2.setCredentials({ refresh_token: process.env.GMAIL_REFRESH_TOKEN });
+  return google.gmail({ version: "v1", auth: oauth2 });
+}
+
+// --- gmailHealth: verify creds by fetching profile + first label ---
+export const gmailHealth = onRequest(
+  {
+    region: "us-central1",
+    secrets: [GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET, GMAIL_REFRESH_TOKEN, GMAIL_REDIRECT_URI],
+    timeoutSeconds: 30
+  },
+  async (_req, res) => {
+    try {
+      const gmail = buildGmailClient();
+      const profile = await gmail.users.getProfile({ userId: "me" });
+      const labels = await gmail.users.labels.list({ userId: "me" });
+      res.json({
+        ok: true,
+        emailAddress: profile.data.emailAddress,
+        labelSample: labels.data.labels?.slice(0, 3) ?? []
+      });
+    } catch (err) {
+      console.error("gmailHealth error:", err);
+      res.status(500).json({ ok: false, error: String(err) });
+    }
+  }
+);
+
+// --- receiveEmailLead: auth via x-webhook-secret; accepts JSON or ADF/XML; writes to Firestore ---
 export const receiveEmailLead = onRequest(
   {
     region: "us-central1",
     secrets: [GMAIL_WEBHOOK_SECRET],
     timeoutSeconds: 30,
-    maxInstances: 10,
+    maxInstances: 10
   },
   async (req, res) => {
     const provided = (req.header("x-webhook-secret") || "").trim();
@@ -43,18 +85,27 @@ export const receiveEmailLead = onRequest(
     }
 
     try {
+      const ct = String(req.headers["content-type"] || "").toLowerCase();
+      // Normalize raw bytes to tolerate PowerShell/curl/body-parsing quirks
+      const raw = typeof req.rawBody === "undefined"
+        ? Buffer.from(typeof req.body === "string" ? req.body : JSON.stringify(req.body ?? {}), "utf8")
+        : Buffer.from(req.rawBody);
+
       let lead;
-      const ct = (req.headers["content-type"] || "").toLowerCase();
 
       if (ct.includes("application/json")) {
-        lead = { ...req.body };
+        let obj = req.body;
+        if (typeof obj === "string" || Buffer.isBuffer(obj)) {
+          const s = Buffer.isBuffer(obj) ? obj.toString("utf8") : obj;
+          obj = s.length ? JSON.parse(s) : {};
+        }
+        lead = { ...obj };
       } else {
-        const xml = req.rawBody?.toString("utf8") || "";
+        const xml = raw.toString("utf8");
         const parsed = await parseStringPromise(xml, { explicitArray: false, trim: true });
         const p = parsed?.adf?.prospect || parsed?.prospect || {};
         const vehicle = p.vehicle || {};
         const contact = p.customer?.contact || p.customer || {};
-
         lead = {
           source: "webhook",
           format: "adf",
@@ -63,28 +114,27 @@ export const receiveEmailLead = onRequest(
             year: vehicle.year || null,
             make: vehicle.make || null,
             model: vehicle.model || null,
-            vin: vehicle.vin || null,
+            vin: vehicle.vin || null
           },
           customer: {
             name: contact?.name?.["_"] || contact?.name || null,
             email: contact?.email || null,
-            phone: contact?.phone || null,
-          },
+            phone: contact?.phone || null
+          }
         };
       }
 
       lead.receivedAt = admin.firestore.FieldValue.serverTimestamp();
       await admin.firestore().collection("leads_v2").add(lead);
-
       return res.status(200).json({ ok: true });
     } catch (err) {
-      console.error(err);
-      return res.status(500).json({ ok: false, error: String(err) });
+      console.error("receiveEmailLead error:", err);
+      return res.status(400).json({ ok: false, error: "Bad request: " + (err instanceof Error ? err.message : String(err)) });
     }
   }
 );
 
-/** Stubbed AI reply — verifies key presence */
+// --- AI stub (unchanged) ---
 export const generateAIReply = onRequest(
   { region: "us-central1", secrets: [OPENAI_API_KEY], timeoutSeconds: 60 },
   async (_req, res) => {
@@ -92,3 +142,4 @@ export const generateAIReply = onRequest(
     return res.json({ ok: true, msg: "AI reply generator is wired." });
   }
 );
+

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "firebase-admin": "^12.6.0",
         "firebase-functions": "^5.1.0",
+        "googleapis": "^131.0.0",
         "xml2js": "^0.6.2"
       },
       "engines": {
@@ -540,7 +541,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 14"
       }
@@ -622,15 +622,13 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -1037,8 +1035,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/farmhash-modern": {
       "version": "1.1.0",
@@ -1215,7 +1212,6 @@
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
       "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -1236,7 +1232,6 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -1246,7 +1241,6 @@
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
       "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "gaxios": "^6.1.1",
         "google-logging-utils": "^0.0.2",
@@ -1308,7 +1302,6 @@
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
       "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -1364,9 +1357,51 @@
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
       "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "131.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-131.0.0.tgz",
+      "integrity": "sha512-fa4kdkY0VwHDw/04ItpQv2tlvlPIwbh6NjHDoWAVrV52GuaZbYCMOC5Y+hRmprp5HHIMRODmyb2YujlbZSRUbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/gopd": {
@@ -1386,7 +1421,6 @@
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
       "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "gaxios": "^6.0.0",
         "jws": "^4.0.0"
@@ -1532,7 +1566,6 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -1546,7 +1579,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1563,8 +1595,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -1608,7 +1639,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       },
@@ -1630,7 +1660,6 @@
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -1689,7 +1718,6 @@
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -1741,7 +1769,6 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
       "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
@@ -1925,7 +1952,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -2528,8 +2554,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -2564,6 +2589,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -2607,8 +2638,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "optional": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -2638,7 +2668,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/functions/package.json
+++ b/functions/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "firebase-admin": "^12.6.0",
     "firebase-functions": "^5.1.0",
+    "googleapis": "^131.0.0",
     "xml2js": "^0.6.2"
   }
 }


### PR DESCRIPTION
## Summary
- add Gmail OAuth helper and `gmailHealth` endpoint to verify credentials
- expand webhook to handle JSON or ADF/XML leads and store to `leads_v2`
- add `googleapis` dependency and stay on Node.js 20 / Gen 2

## Testing
- `npm ci`
- `npm test` *(fails: Missing script "test")*
- `npm test` (root) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689fa21e9a248325921a193841f013ff