### PR TITLE
refactor: use modular Firestore

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -2,6 +2,7 @@
 import { onRequest } from "firebase-functions/v2/https";
 import { defineSecret } from "firebase-functions/params";
 import * as admin from "firebase-admin";
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
 import { google } from "googleapis";
 import { parseStringPromise } from "xml2js";
 
@@ -124,8 +125,9 @@ export const receiveEmailLead = onRequest(
         };
       }
 
-      lead.receivedAt = admin.firestore.FieldValue.serverTimestamp();
-      await admin.firestore().collection("leads_v2").add(lead);
+      const db = getFirestore();
+      lead.receivedAt = FieldValue.serverTimestamp();
+      await db.collection("leads_v2").add(lead);
       return res.status(200).json({ ok: true });
     } catch (err) {
       console.error("receiveEmailLead error:", err);


### PR DESCRIPTION
## Summary
- switch Firestore calls to modular API

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a006a41a6c8325976d097aa30038a2