### PR TITLE
refactor: use modular Firestore

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -10,6 +10,8 @@ if (getApps().length === 0) {
   initializeApp(); // uses the default service account in Cloud Functions
 }
 
+const db = getFirestore();
+
 // Secrets (mounted via Google Secret Manager)
 const GMAIL_WEBHOOK_SECRET = defineSecret("GMAIL_WEBHOOK_SECRET");
 const OPENAI_API_KEY       = defineSecret("OPENAI_API_KEY");
@@ -127,7 +129,6 @@ export const receiveEmailLead = onRequest(
         };
       }
 
-      const db = getFirestore();
       lead.receivedAt = FieldValue.serverTimestamp();
       await db.collection("leads_v2").add(lead);
       return res.status(200).json({ ok: true });

--- a/scripts/run-admin.cjs
+++ b/scripts/run-admin.cjs
@@ -1,4 +1,5 @@
-const admin = require('firebase-admin');
+const { initializeApp, cert } = require('firebase-admin/app');
+const { getFirestore } = require('firebase-admin/firestore');
 
 function fail(msg, err) {
   console.error(msg);
@@ -13,8 +14,8 @@ try { sa = JSON.parse(raw); } catch (e) { fail('GCP_SA_KEY is not valid JSON.', 
 if (!sa.client_email || !sa.private_key) fail('JSON missing client_email/private_key.');
 
 try {
-  admin.initializeApp({
-    credential: admin.credential.cert(sa),
+  initializeApp({
+    credential: cert(sa),
     projectId: process.env.GOOGLE_CLOUD_PROJECT,
   });
 } catch (e) {
@@ -22,7 +23,7 @@ try {
 }
 
 const databaseId = process.env.FIRESTORE_DATABASE_ID || 'leads';
-const db = admin.firestore();
+const db = getFirestore();
 db.settings({ databaseId }); // target non-default DB immediately
 
 (async () => {


### PR DESCRIPTION
## Summary
- initialize Firebase with modular `firebase-admin/app` APIs
- replace legacy `admin.firestore()` usage with `getFirestore`

## Testing
- `npm test` *(fails: Missing script "test")*
- `(cd functions && npm test)` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a006a41a6c8325976d097aa30038a2