### PR TITLE
Specify Firestore project ID

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -8,7 +8,7 @@ import { parseStringPromise } from "xml2js";
 
 // Initialize the Admin SDK once
 if (getApps().length === 0) {
-  initializeApp(); // uses default service account in Functions v2
+  initializeApp({ projectId: "priority-lead-sync" });
 }
 
 // Secrets (mounted via Google Secret Manager)


### PR DESCRIPTION
## Summary
- initialize Firebase Admin SDK with explicit `priority-lead-sync` project ID to avoid Firestore NOT_FOUND errors

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_68a0168aa78c8325a370b45cf516ea3f