### PR TITLE
refactor: stabilize firebase functions and secrets

### DIFF
--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -3,6 +3,8 @@ node_modules/
 
 # Firebase credentials
 .env
+.env.*
+!.env.example
 credentials.json
 
 # OS-specific


### PR DESCRIPTION
## Summary
- modernize functions to use modular Firebase Admin SDK and add Firestore health check endpoint
- expand secret verification and Gmail OAuth health diagnostics
- ignore local `.env*` files to prevent secret collisions

## Testing
- `npm test` *(fails: Missing script "test")*

## Post-Patch Instructions
1. Delete any committed env files and ensure `functions/.env` is absent.
2. Deploy endpoints sequentially:
   ```bash
   firebase deploy --project priority-lead-sync --only "functions:health"
   firebase deploy --project priority-lead-sync --only "functions:testSecrets"
   firebase deploy --project priority-lead-sync --only "functions:firestoreHealth"
   firebase deploy --project priority-lead-sync --only "functions:receiveEmailLead"
   firebase deploy --project priority-lead-sync --only "functions:gmailHealth"
   firebase deploy --project priority-lead-sync --only "functions:generateAIReply"
   ```
3. Sanity checks:
   - **Secrets present**: GET `https://testsecrets-<hash>-uc.a.run.app`
   - **Firestore ready**: GET `https://firestorehealth-<hash>-uc.a.run.app`
   - **Webhook write**:
     ```powershell
     Invoke-WebRequest -Uri "https://receiveemaillead-<hash>-uc.a.run.app" -Method POST -Headers @{"x-webhook-secret"="PriorityLead2025SecretKey"} -Body '{"source":"webhook","format":"json","subject":"Test Lead","from":"customer@example.com","body":"Interested in a Lexus RX350"}' -ContentType "application/json" | Select-Object -Expand Content
     ```
   - **Gmail health**: GET `https://gmailhealth-<hash>-uc.a.run.app`


------
https://chatgpt.com/codex/tasks/task_e_68a0196d4570832594d804b61c36b727