### PR TITLE
Add webhook test scripts and Firestore rules

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,5 +6,8 @@
   "hosting": {
     "public": "public",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+  },
+  "firestore": {
+    "rules": "firestore.rules"
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,11 @@
+// Only allow reads to authenticated users (tune as needed), block writes.
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Tighten by path if you expose a dashboard later
+    match /{document=**} {
+      allow read: if request.auth != null;
+      allow write: if false;
+    }
+  }
+}

--- a/tests/Priority-Lead-Sync.postman_collection.json
+++ b/tests/Priority-Lead-Sync.postman_collection.json
@@ -1,0 +1,71 @@
+{
+  "info": {
+    "name": "Priority Lead Sync",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_postman_id": "7cf6a44f-0a51-45a8-9e2c-PLS"
+  },
+  "item": [
+    {
+      "name": "health",
+      "request": { "method": "GET", "url": { "raw": "{{baseUrlRoot}}/health", "host": ["{{baseUrlRoot}}"], "path": ["health"] } }
+    },
+    {
+      "name": "testSecrets",
+      "request": { "method": "GET", "url": { "raw": "{{baseUrlRoot}}/testSecrets", "host": ["{{baseUrlRoot}}"], "path": ["testSecrets"] } }
+    },
+    {
+      "name": "gmailHealth",
+      "request": { "method": "GET", "url": { "raw": "{{baseUrlRoot}}/gmailHealth", "host": ["{{baseUrlRoot}}"], "path": ["gmailHealth"] } }
+    },
+    {
+      "name": "firestoreHealth",
+      "request": { "method": "GET", "url": { "raw": "{{baseUrlRoot}}/firestoreHealth", "host": ["{{baseUrlRoot}}"], "path": ["firestoreHealth"] } }
+    },
+    {
+      "name": "receiveEmailLead (JSON)",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "x-webhook-secret", "value": "{{webhookSecret}}" },
+          { "key": "Content-Type", "value": "application/json" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"source\":\"webhook\",\n  \"format\":\"json\",\n  \"subject\":\"Test Lead (JSON)\",\n  \"from\":\"customer@example.com\",\n  \"body\":\"Interested in a Lexus RX350\",\n  \"vehicle\": {\"year\":\"2025\",\"make\":\"Lexus\",\"model\":\"RX 350\"},\n  \"customer\": {\"name\":\"Test Lead\",\"email\":\"lead@example.com\",\"phone\":\"555-123-4567\"},\n  \"requestDate\":\"{{nowIso}}\"\n}"
+        },
+        "url": { "raw": "{{baseUrl}}", "host": ["{{baseUrl}}"] }
+      }
+    },
+    {
+      "name": "receiveEmailLead (ADF/XML)",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "x-webhook-secret", "value": "{{webhookSecret}}" },
+          { "key": "Content-Type", "value": "application/xml" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<adf>\n  <prospect>\n    <requestdate>{{nowIso}}</requestdate>\n    <vehicle>\n      <year>2025</year>\n      <make>Lexus</make>\n      <model>RX 350</model>\n      <vin>2T3S1RFY1RC123456</vin>\n    </vehicle>\n    <customer>\n      <contact>\n        <name>XML Tester</name>\n        <email>xmltester@example.com</email>\n        <phone>555-555-0000</phone>\n      </contact>\n    </customer>\n  </prospect>\n</adf>"
+        },
+        "url": { "raw": "{{baseUrl}}", "host": ["{{baseUrl}}"] }
+      }
+    }
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "exec": [
+          "pm.variables.set('nowIso', new Date().toISOString());"
+        ],
+        "type": "text/javascript"
+      }
+    }
+  ],
+  "variable": [
+    { "key": "baseUrlRoot", "value": "https://us-central1-priority-lead-sync.cloudfunctions.net" },
+    { "key": "baseUrl", "value": "https://receiveemaillead-puboig54jq-uc.a.run.app" },
+    { "key": "webhookSecret", "value": "PriorityLead2025SecretKey" }
+  ]
+}

--- a/tests/test-webhook.ps1
+++ b/tests/test-webhook.ps1
@@ -1,0 +1,58 @@
+# ====== CONFIG ======
+$BaseUrl = "https://receiveemaillead-puboig54jq-uc.a.run.app"
+$Secret  = "PriorityLead2025SecretKey"   # x-webhook-secret you set in Secret Manager
+
+Function Invoke-JsonTest {
+  $json = @{
+    source      = "webhook"
+    format      = "json"
+    subject     = "Test Lead (JSON)"
+    from        = "customer@example.com"
+    body        = "Interested in a Lexus RX350"
+    vehicle     = @{ year="2025"; make="Lexus"; model="RX 350" }
+    customer    = @{ name="Test Lead"; email="lead@example.com"; phone="555-123-4567" }
+    requestDate = (Get-Date).ToUniversalTime().ToString("o")
+  } | ConvertTo-Json -Depth 7
+
+  Write-Host "`n--- JSON test ---"
+  $resp = Invoke-WebRequest -Uri $BaseUrl -Method POST `
+    -Headers @{ "x-webhook-secret" = $Secret } `
+    -ContentType "application/json; charset=utf-8" `
+    -Body $json
+  $resp.Content
+}
+
+Function Invoke-AdfXmlTest {
+  $xml = @"
+<?xml version="1.0" encoding="UTF-8"?>
+<adf>
+  <prospect>
+    <requestdate>$(Get-Date -Format s)Z</requestdate>
+    <vehicle>
+      <year>2025</year>
+      <make>Lexus</make>
+      <model>RX 350</model>
+      <vin>2T3S1RFY1RC123456</vin>
+    </vehicle>
+    <customer>
+      <contact>
+        <name>XML Tester</name>
+        <email>xmltester@example.com</email>
+        <phone>555-555-0000</phone>
+      </contact>
+    </customer>
+  </prospect>
+</adf>
+"@
+
+  Write-Host "`n--- ADF/XML test ---"
+  $resp = Invoke-WebRequest -Uri $BaseUrl -Method POST `
+    -Headers @{ "x-webhook-secret" = $Secret } `
+    -ContentType "application/xml; charset=utf-8" `
+    -Body ([System.Text.Encoding]::UTF8.GetBytes($xml))
+  $resp.Content
+}
+
+# Run both tests
+Invoke-JsonTest
+Invoke-AdfXmlTest


### PR DESCRIPTION
## Summary
- add PowerShell script and Postman collection to exercise webhook endpoints
- define restrictive Firestore security rules and reference them in firebase config

## Testing
- `npx --yes newman run tests/Priority-Lead-Sync.postman_collection.json --verbose`

------
https://chatgpt.com/codex/tasks/task_e_68a0eb6df4f48325a6366b2037b469d4