### PR TITLE
chore: harden deployment and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
 
     env:
-      PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+      FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
 
     steps:
       - name: Checkout
@@ -48,23 +48,23 @@ jobs:
       # Write SA JSON from GitHub secret for deploy steps
       - name: Write service account JSON
         run: |
-          echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > $HOME/fb-sa.json
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/fb-sa.json" >> $GITHUB_ENV
+          echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > $HOME/gcloud-key.json
+          echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/gcloud-key.json" >> $GITHUB_ENV
 
       # Deploy functions on main only
       - name: Deploy Cloud Functions
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           firebase deploy \
-            --project "$PROJECT_ID" \
-            --only "functions:receiveEmailLead,functions:firestoreHealth,functions:gmailHealth,functions:testSecrets" \
+            --project "$FIREBASE_PROJECT_ID" \
+            --only "functions:health,functions:testSecrets,functions:firestoreHealth,functions:gmailHealth,functions:receiveEmailLead,functions:generateAIReply" \
             --non-interactive --force
 
       # Deploy Firestore rules on main only
       - name: Deploy Firestore rules
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
-          firebase deploy --project "$PROJECT_ID" --only firestore:rules --non-interactive --force
+          firebase deploy --project "$FIREBASE_PROJECT_ID" --only firestore:rules --non-interactive --force
 
       # Optional health checks on main only (won't fail if unset)
       - name: Health probes (optional)

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 
 # Environment files
 .env
+.env.*
 
 # Build output
 dist/

--- a/Runbook.md
+++ b/Runbook.md
@@ -1,0 +1,31 @@
+# Priority Lead Sync Runbook
+
+## Endpoints
+- **health**: https://health-puboig54jq-uc.a.run.app
+- **testSecrets**: https://testsecrets-puboig54jq-uc.a.run.app
+- **firestoreHealth**: https://firestorehealth-puboig54jq-uc.a.run.app
+- **gmailHealth**: https://gmailhealth-puboig54jq-uc.a.run.app
+- **receiveEmailLead**: https://receiveemaillead-puboig54jq-uc.a.run.app
+
+## Secrets (names only)
+- FIREBASE_PROJECT_ID
+- FIREBASE_SERVICE_ACCOUNT
+- WEBHOOK_BASE_URL
+- GMAIL_WEBHOOK_SECRET
+- OPENAI_API_KEY
+- GMAIL_CLIENT_ID
+- GMAIL_CLIENT_SECRET
+- GMAIL_REFRESH_TOKEN
+- GMAIL_REDIRECT_URI
+- (optional) HEALTH_FIRESTORE_URL, HEALTH_GMAIL_URL, HEALTH_TESTSECRETS_URL
+
+## Tests
+- `npm test --prefix functions`
+- `newman run tests/Priority-Lead-Sync.postman_collection.json --env-var baseUrl=$WEBHOOK_BASE_URL --env-var webhookSecret=$GMAIL_WEBHOOK_SECRET`
+
+## CI
+GitHub Actions workflow at `.github/workflows/ci.yml` installs deps, runs unit tests and Postman smoke tests, then deploys Cloud Functions and Firestore rules using the service account in secrets.
+
+## Troubleshooting
+- `curl $HEALTH_FIRESTORE_URL`, `curl $HEALTH_GMAIL_URL`, `curl $HEALTH_TESTSECRETS_URL` for basic checks.
+- Firestore writes are stored in the `leads_v2` collection.

--- a/functions/index.js
+++ b/functions/index.js
@@ -26,7 +26,7 @@ const GMAIL_REDIRECT_URI   = defineSecret("GMAIL_REDIRECT_URI");
 
 /** ---------- Health (simple) ---------- */
 export const health = onRequest({ region: "us-central1" }, (_req, res) => {
-  res.status(200).send("ok");
+  res.status(200).json({ ok: true, timestamp: new Date().toISOString() });
 });
 
 /** ---------- Secrets check (no values leaked) ---------- */


### PR DESCRIPTION
## Summary
- return JSON from `/health`
- deploy full function set and use explicit Firebase env in CI
- document endpoints and secrets in Runbook

## Testing
- `npm test --prefix functions`
- `newman run tests/Priority-Lead-Sync.postman_collection.json --env-var baseUrl=https://receiveemaillead-puboig54jq-uc.a.run.app --env-var webhookSecret=PriorityLead2025SecretKey`
- `curl -s https://health-puboig54jq-uc.a.run.app -w '\n'`
- `curl -s https://testsecrets-puboig54jq-uc.a.run.app -w '\n'`
- `curl -s https://firestorehealth-puboig54jq-uc.a.run.app -w '\n'`
- `curl -s https://gmailhealth-puboig54jq-uc.a.run.app -w '\n'`


------
https://chatgpt.com/codex/tasks/task_e_68a20f39b7dc8325bdf9dd23a2c844fa