### PR TITLE
feat: add lead notifications and firestore client

### DIFF
--- a/electron-app/package-lock.json
+++ b/electron-app/package-lock.json
@@ -13,7 +13,7 @@
         "dotenv": "^17.2.1",
         "electron": "^37.2.6",
         "electron-store": "^10.1.0",
-        "firebase": "^12.1.0",
+        "firebase": "^10.14.1",
         "firebase-admin": "^13.4.0",
         "play-sound": "^1.1.6"
       },

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -5,7 +5,12 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "package-win": "npx @electron/packager . lead-notifier --platform=win32 --arch=x64 --out=dist --overwrite"
+    "package-win": "npx @electron/packager . lead-notifier --platform=win32 --arch=x64 --out=dist --overwrite",
+    "dev": "concurrently -k -r \"npm:dev:*\"",
+    "dev:main": "electron .",
+    "dev:renderer": "vite",
+    "build": "vite build",
+    "dist": "electron-builder"
   },
   "author": "Rob Brasco",
   "license": "MIT",
@@ -14,11 +19,14 @@
     "dotenv": "^17.2.1",
     "electron": "^37.2.6",
     "electron-store": "^10.1.0",
-    "firebase": "^12.1.0",
+    "firebase": "^10.14.1",
     "firebase-admin": "^13.4.0",
     "play-sound": "^1.1.6"
   },
   "devDependencies": {
-    "@electron/packager": "^18.0.0"
+    "@electron/packager": "^18.0.0",
+    "concurrently": "^9.2.0",
+    "electron-builder": "^26.0.12",
+    "vite": "^7.1.2"
   }
 }

--- a/electron-app/src/main/preload.ts
+++ b/electron-app/src/main/preload.ts
@@ -1,0 +1,6 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('leadSync', {
+  notify: (title: string, body: string) => ipcRenderer.invoke('notify', { title, body }),
+  openLeads: () => ipcRenderer.invoke('open-leads')
+});

--- a/electron-app/src/renderer/bootstrap.ts
+++ b/electron-app/src/renderer/bootstrap.ts
@@ -1,0 +1,29 @@
+import { subscribeToLeads } from './firestore';
+import { saveLastSeen, wasSeen } from './store';
+
+declare global {
+  interface Window {
+    leadSync: { notify: (t: string, b: string) => void; openLeads: () => void };
+  }
+}
+
+function render(doc: any) {
+  const container = document.querySelector('#leads');
+  if (!container) return;
+  const item = document.createElement('div');
+  item.className = 'lead';
+  const title = doc?.customer?.name || doc?.subject || 'New Lead';
+  const sub = [doc?.vehicle?.year, doc?.vehicle?.make, doc?.vehicle?.model].filter(Boolean).join(' ');
+  item.innerHTML = `<div class="title">${title}</div><div class="sub">${sub || ''}</div>`;
+  container.prepend(item);
+}
+
+subscribeToLeads((doc) => {
+  if (wasSeen(doc.id)) return;
+  saveLastSeen(doc.id);
+
+  const title = doc?.customer?.name || doc?.subject || 'New Lead';
+  const sub = [doc?.vehicle?.year, doc?.vehicle?.make, doc?.vehicle?.model].filter(Boolean).join(' ');
+  window.leadSync?.notify(title, sub || 'New web lead received');
+  render(doc);
+});

--- a/electron-app/src/renderer/firestore.ts
+++ b/electron-app/src/renderer/firestore.ts
@@ -1,0 +1,29 @@
+import { initializeApp } from 'firebase/app';
+import {
+  getFirestore, collection, query, orderBy, limit, onSnapshot
+} from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: import.meta.env?.VITE_FIREBASE_API_KEY ?? (process.env.VITE_FIREBASE_API_KEY as string),
+  authDomain: import.meta.env?.VITE_FIREBASE_AUTH_DOMAIN ?? (process.env.VITE_FIREBASE_AUTH_DOMAIN as string),
+  projectId: import.meta.env?.VITE_FIREBASE_PROJECT_ID ?? (process.env.VITE_FIREBASE_PROJECT_ID as string),
+  storageBucket: import.meta.env?.VITE_FIREBASE_STORAGE_BUCKET ?? (process.env.VITE_FIREBASE_STORAGE_BUCKET as string),
+  messagingSenderId: import.meta.env?.VITE_FIREBASE_MESSAGING_SENDER_ID ?? (process.env.VITE_FIREBASE_MESSAGING_SENDER_ID as string),
+  appId: import.meta.env?.VITE_FIREBASE_APP_ID ?? (process.env.VITE_FIREBASE_APP_ID as string),
+};
+
+const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);
+
+export function subscribeToLeads(onLead: (doc: any) => void) {
+  const ref = collection(db, 'leads_v2');
+  const q = query(ref, orderBy('receivedAt', 'desc'), limit(25));
+  return onSnapshot(q, (snap) => {
+    snap.docChanges().forEach((change) => {
+      if (change.type === 'added') {
+        const doc = { id: change.doc.id, ...change.doc.data() };
+        onLead(doc);
+      }
+    });
+  });
+}

--- a/electron-app/src/renderer/index.html
+++ b/electron-app/src/renderer/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Priority Lead Sync</title>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'">
+    <style>
+      body { font-family: system-ui, Segoe UI, Arial, sans-serif; margin: 16px; }
+      #leads { display: grid; gap: 10px; }
+      .lead { padding: 10px; border-radius: 12px; box-shadow: 0 1px 8px rgba(0,0,0,0.08); }
+      .title { font-weight: 600; }
+      .sub { opacity: 0.8; }
+    </style>
+  </head>
+  <body>
+    <h1>Leads</h1>
+    <div id="leads"></div>
+    <script type="module" src="/src/renderer/bootstrap.ts"></script>
+  </body>
+</html>

--- a/electron-app/src/renderer/store.ts
+++ b/electron-app/src/renderer/store.ts
@@ -1,0 +1,16 @@
+const KEY = 'leadsync-last-seen';
+
+export function saveLastSeen(id: string) {
+  const list = load();
+  if (!list.includes(id)) list.unshift(id);
+  localStorage.setItem(KEY, JSON.stringify(list.slice(0, 200)));
+}
+
+export function wasSeen(id: string): boolean {
+  return load().includes(id);
+}
+
+function load(): string[] {
+  try { return JSON.parse(localStorage.getItem(KEY) || '[]'); }
+  catch { return []; }
+}


### PR DESCRIPTION
## Summary
- expose notification and navigation APIs via preload script
- subscribe to Firestore leads and render unseen items
- wire IPC handlers and development scripts for building

## Testing
- `npm run dev` *(fails: concurrently: not found)*
- `npm run dist` *(fails: electron-builder: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a25f524c10832593041b05fd4b421c