### PR TITLE
chore: add stub test script

### DIFF
--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -9,7 +9,8 @@
     "dev:preload": "esbuild src/main/preload.ts --bundle --platform=node --format=cjs --outfile=dist/main/preload.cjs --sourcemap --watch",
     "dev:main": "cross-env VITE_DEV_SERVER_URL=http://localhost:5173 wait-on tcp:5173 && electron .",
     "build": "vite build && esbuild src/main/preload.ts --bundle --platform=node --format=cjs --outfile=dist/main/preload.cjs",
-    "dist": "npm run build && electron-builder"
+    "dist": "npm run build && electron-builder",
+    "test": "echo \"No tests configured\" && exit 0"
   },
   "build": {
     "appId": "com.priority.leadsync",


### PR DESCRIPTION
## Summary
- add placeholder npm test script to electron app package

## Testing
- `cd electron-app && npm test`
- `cd electron-app && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a373abc65c8325b058077b0da76cb2