### PR TITLE
chore: document and script Linux prerequisites for Electron app

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ curl.exe -X POST "https://us-central1-YOUR_PROJECT.cloudfunctions.net/receiveEma
 
 The `electron-app` directory provides a small Electron application that listens for new leads in the `leads_v2` Firestore collection and displays desktop notifications.
 
+### Linux prerequisites
+
+Running the Electron app in development or creating distributable packages on Linux requires several native libraries. On Debian or Ubuntu based systems you can install them with:
+
+```bash
+scripts/install-linux-deps.sh
+```
+
+This installs `libatk1.0-0`, `libatk-bridge2.0-0`, `libgtk-3-0` (needed for `npm run dev`) and `squashfs-tools` (provides `mksquashfs` for `npm run dist`).
+
 ### Packaging the Electron app for Windows
 
 1. `cd electron-app`

--- a/scripts/install-linux-deps.sh
+++ b/scripts/install-linux-deps.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v apt-get >/dev/null; then
+  echo "apt-get not found. This script supports Debian/Ubuntu-based systems." >&2
+  exit 1
+fi
+
+packages=(libatk1.0-0 libatk-bridge2.0-0 libgtk-3-0 squashfs-tools)
+
+if [ "$(id -u)" -ne 0 ]; then
+  SUDO=sudo
+else
+  SUDO=
+fi
+
+$SUDO apt-get update
+$SUDO apt-get install -y "${packages[@]}"


### PR DESCRIPTION
## Summary
- document Linux packages needed for `npm run dev` and `npm run dist`
- add `scripts/install-linux-deps.sh` to install GTK and squashfs dependencies

## Testing
- `npm test --prefix functions --silent`
- `cd electron-app && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a383ce49c8832599b44f5a2a2829d7