### PR TITLE
ci: install linux deps for electron builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,16 @@ jobs:
       - name: Run unit tests (functions)
         run: npm test --prefix functions --silent
 
+      # Electron build
+      - name: Install Electron deps
+        run: npm ci --prefix electron-app
+
+      - name: Install Linux deps for Electron
+        run: ./scripts/install-linux-deps.sh
+
+      - name: Package Electron app
+        run: npm run dist --prefix electron-app
+
       # Postman smoke tests against live webhook
       - name: Postman smoke tests (JSON + ADF/XML)
         run: |

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Running the Electron app in development or creating distributable packages on Li
 scripts/install-linux-deps.sh
 ```
 
-This installs `libatk1.0-0`, `libatk-bridge2.0-0`, `libgtk-3-0` (needed for `npm run dev`) and `squashfs-tools` (provides `mksquashfs` for `npm run dist`).
+This installs `libatk1.0-0`, `libatk-bridge2.0-0`, `libgtk-3-0`, `libnss3`, and `libdrm2` (needed for `npm run dev`) plus `squashfs-tools` (provides `mksquashfs` for `npm run dist`).
 
 ### Packaging the Electron app for Windows
 

--- a/scripts/install-linux-deps.sh
+++ b/scripts/install-linux-deps.sh
@@ -6,7 +6,7 @@ if ! command -v apt-get >/dev/null; then
   exit 1
 fi
 
-packages=(libatk1.0-0 libatk-bridge2.0-0 libgtk-3-0 squashfs-tools)
+packages=(libatk1.0-0 libatk-bridge2.0-0 libgtk-3-0 libnss3 libdrm2 squashfs-tools)
 
 if [ "$(id -u)" -ne 0 ]; then
   SUDO=sudo


### PR DESCRIPTION
## Summary
- add Linux dependency installer script for Electron
- document required system packages
- run packaging in CI after installing native deps

## Testing
- `npm test --prefix functions --silent`
- `npm run dist --prefix electron-app`


------
https://chatgpt.com/codex/tasks/task_e_68a38ccf17388325a2ec2a1600009467