### PR TITLE
refactor: align electron renderer build with Vite and dev URL

### DIFF
--- a/electron-app/index.html
+++ b/electron-app/index.html
@@ -3,19 +3,11 @@
   <head>
     <meta charset="utf-8" />
     <title>Priority Lead Sync</title>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'">
-    <style>
-      body { font-family: system-ui, Segoe UI, Arial, sans-serif; margin: 16px; }
-      #leads { display: grid; gap: 10px; }
-      .lead { padding: 10px; border-radius: 12px; box-shadow: 0 1px 8px rgba(0,0,0,0.08); }
-      .title { font-weight: 600; }
-      .sub { opacity: 0.8; }
-    </style>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>
   <body>
-    <h1>Leads</h1>
-    <div id="leads"></div>
-    <script type="module" src="/src/renderer/bootstrap.ts"></script>
+    <div id="app">Loading…</div>
+    <script type="module" src="./src/renderer/bootstrap.ts"></script>
   </body>
 </html>
 

--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -3,8 +3,11 @@ const { app, BrowserWindow } = require('electron');
 const path = require('node:path');
 
 function createWindow() {
-  const isDev = Boolean(process.env.VITE_DEV_SERVER_URL);
-  const devUrl = process.env.VITE_DEV_SERVER_URL; // e.g. http://localhost:5173
+  const devUrl = process.env.VITE_DEV_SERVER_URL;
+  const isDev = Boolean(devUrl);
+
+  console.log('[main] VITE_DEV_SERVER_URL =', devUrl || '(none)');
+  console.log('[main] mode =', isDev ? 'DEV' : 'PROD');
 
   const win = new BrowserWindow({
     width: 1100,
@@ -16,13 +19,13 @@ function createWindow() {
     },
   });
 
-  if (isDev && devUrl) {
-    console.log('[main] DEV ->', devUrl);
+  if (isDev) {
+    console.log('[main] Loading dev URL ->', devUrl);
     win.loadURL(devUrl);
     win.webContents.openDevTools({ mode: 'detach' });
   } else {
     const indexFile = path.join(__dirname, 'dist', 'renderer', 'index.html');
-    console.log('[main] PROD ->', indexFile);
+    console.log('[main] Loading prod file ->', indexFile);
     win.loadFile(indexFile);
   }
 }

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -15,17 +15,17 @@
   "build": {
     "appId": "com.priority.leadsync",
     "productName": "Priority Lead Sync",
+    "directories": { "output": "dist" },
     "files": [
-      "dist/**/*",
-      "src/**/*",
-      "main.js",
-      "package.json"
+      "dist/main/**",
+      "dist/renderer/**",
+      "package.json",
+      "main.js"
     ],
-    "directories": {
-      "output": "dist"
-    },
-    "win": {
-      "target": "nsis"
+    "win": { "target": "nsis" },
+    "nsis": {
+      "oneClick": true,
+      "allowToChangeInstallationDirectory": false
     }
   },
   "author": "Rob Brasco",

--- a/electron-app/vite.config.js
+++ b/electron-app/vite.config.js
@@ -2,16 +2,14 @@ import { defineConfig } from 'vite';
 import path from 'node:path';
 
 export default defineConfig({
-  root: '.',
+  root: '.',                  // renderer lives at project root now
+  server: { port: 5173 },
   build: {
-    outDir: 'dist/renderer',
+    outDir: path.resolve(__dirname, 'dist/renderer'),
     emptyOutDir: true,
     rollupOptions: {
-      input: 'src/renderer/index.html'
-    }
+      input: path.resolve(__dirname, 'index.html'), // entry is the root index.html
+    },
   },
-  server: {
-    port: 5173
-  }
 });
 


### PR DESCRIPTION
## Summary
- align Vite config with renderer at project root
- log and prefer dev server URL in Electron main process
- update Electron build config and minimal renderer entry

## Testing
- `cd electron-app && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4b66b47ac8325b53969d571edd331