### PR TITLE
fix: allow preload Node APIs by disabling sandbox

### DIFF
--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -36,9 +36,9 @@ async function createWindow() {
     height: 800,
     webPreferences: {
       preload,
-      sandbox: true,
+      contextIsolation: true,
       nodeIntegration: false,
-      contextIsolation: true
+      sandbox: false,           // allow Node built-ins in preload
     }
   });
 


### PR DESCRIPTION
## Summary
- disable BrowserWindow sandbox so preload has access to Node built-ins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4ef3b60a083258ac31320b67d1df7