### PR TITLE
Externalize electron in preload build

### DIFF
--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -30,15 +30,15 @@ async function resolvePreload() {
 }
 
 async function createWindow() {
-  const preload = await resolvePreload();
+  const preloadPath = await resolvePreload();
   const win = new BrowserWindow({
     width: 1200,
     height: 800,
     webPreferences: {
-      preload,
+      preload: preloadPath,
       contextIsolation: true,
       nodeIntegration: false,
-      sandbox: false,           // allow Node built-ins in preload
+      sandbox: false, // must be false so preload has Node built-ins
     }
   });
 

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "dev": "concurrently -k -r \"npm:dev:*\"",
     "dev:renderer": "vite",
-    "dev:preload": "esbuild src/main/preload.ts --bundle --platform=node --format=cjs --outfile=dist/main/preload.cjs --sourcemap --watch",
+    "dev:preload": "esbuild src/main/preload.ts --bundle --platform=node --format=cjs --outfile=dist/main/preload.cjs --sourcemap --watch --external:electron",
     "dev:main": "cross-env VITE_DEV_SERVER_URL=http://localhost:5173 wait-on tcp:5173 && cross-env VITE_DEV_SERVER_URL=http://localhost:5173 electron .",
-    "build": "vite build && esbuild src/main/preload.ts --bundle --platform=node --format=cjs --outfile=dist/main/preload.cjs --sourcemap",
+    "build": "vite build && esbuild src/main/preload.ts --bundle --platform=node --format=cjs --outfile=dist/main/preload.cjs --sourcemap --external:electron",
     "dist": "npm run build && electron-builder",
     "test": "echo \"(placeholder)\" && exit 0"
   },


### PR DESCRIPTION
## Summary
- prevent esbuild from bundling the Electron runtime by marking `electron` as external
- open BrowserWindow with sandbox disabled while keeping context isolation and nodeIntegration off

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4f2b416a48325ad8f854c136b5f12