### PR TITLE
feat: warm instances and boot logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # Environment files
 .env
 .env.*
+functions/.env
 
 # Build output
 dist/

--- a/functions/index.js
+++ b/functions/index.js
@@ -3,6 +3,7 @@ import { onRequest } from "firebase-functions/v2/https";
 import { defineSecret } from "firebase-functions/params";
 import { getApps, initializeApp, getApp } from "firebase-admin/app";
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
+import * as admin from "firebase-admin";
 import { google } from "googleapis";
 import { parseStringPromise } from "xml2js";
 
@@ -11,6 +12,12 @@ if (getApps().length === 0) {
   initializeApp({ projectId: "priority-lead-sync" });
 }
 const db = getFirestore(undefined, "leads");
+
+console.log("[boot] functions module loaded", {
+  node: process.version,
+  time: new Date().toISOString(),
+  projectId: admin.app().options.projectId,
+});
 
 // (If you reference FieldValue elsewhere, switch to the imported one)
 // example:
@@ -25,14 +32,19 @@ const GMAIL_REFRESH_TOKEN  = defineSecret("GMAIL_REFRESH_TOKEN");
 const GMAIL_REDIRECT_URI   = defineSecret("GMAIL_REDIRECT_URI");
 
 /** ---------- Health (simple) ---------- */
-export const health = onRequest({ region: "us-central1" }, (_req, res) => {
-  res.status(200).json({ ok: true, timestamp: new Date().toISOString() });
-});
+export const health = onRequest(
+  { region: "us-central1", minInstances: 1, timeoutSeconds: 30 },
+  (_req, res) => {
+    res.status(200).json({ ok: true, timestamp: new Date().toISOString() });
+  }
+);
 
 /** ---------- Secrets check (no values leaked) ---------- */
 export const testSecrets = onRequest(
   {
     region: "us-central1",
+    minInstances: 1,
+    timeoutSeconds: 30,
     secrets: [
       GMAIL_WEBHOOK_SECRET,
       OPENAI_API_KEY,
@@ -59,34 +71,38 @@ export const testSecrets = onRequest(
 );
 
 /** ---------- Firestore health: default DB (no custom databaseId) ---------- */
-export const firestoreHealth = onRequest({ region: "us-central1" }, async (_req, res) => {
-  try {
-    const ref = db.collection("ci-checks").doc("last-run");
-    await ref.set(
-      {
-        ranAt: new Date().toISOString(),
-        // record where this ran, for sanity
-        projectId: getApp().options.projectId || "unknown",
-        node: process.version,
-      },
-      { merge: true }
-    );
-    const snap = await ref.get();
-    return res.status(200).json({
-      ok: true,
-      exists: snap.exists,
-      data: snap.exists ? snap.data() : null,
-    });
-  } catch (err) {
-    console.error(err);
-    return res.status(500).json({ ok: false, error: String(err) });
+export const firestoreHealth = onRequest(
+  { region: "us-central1", minInstances: 1, timeoutSeconds: 30 },
+  async (_req, res) => {
+    try {
+      const ref = db.collection("ci-checks").doc("last-run");
+      await ref.set(
+        {
+          ranAt: new Date().toISOString(),
+          // record where this ran, for sanity
+          projectId: getApp().options.projectId || "unknown",
+          node: process.version,
+        },
+        { merge: true }
+      );
+      const snap = await ref.get();
+      return res.status(200).json({
+        ok: true,
+        exists: snap.exists,
+        data: snap.exists ? snap.data() : null,
+      });
+    } catch (err) {
+      console.error(err);
+      return res.status(500).json({ ok: false, error: String(err) });
+    }
   }
-});
+);
 
 /** ---------- Gmail OAuth health ---------- */
 export const gmailHealth = onRequest(
   {
     region: "us-central1",
+    minInstances: 1,
     secrets: [GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET, GMAIL_REFRESH_TOKEN, GMAIL_REDIRECT_URI],
     timeoutSeconds: 30,
   },
@@ -123,6 +139,7 @@ export const gmailHealth = onRequest(
 export const receiveEmailLead = onRequest(
   {
     region: "us-central1",
+    minInstances: 1,
     secrets: [GMAIL_WEBHOOK_SECRET],
     timeoutSeconds: 30,
     maxInstances: 10,
@@ -183,7 +200,12 @@ export const receiveEmailLead = onRequest(
 
 /** ---------- Stubbed AI reply (key presence check) ---------- */
 export const generateAIReply = onRequest(
-  { region: "us-central1", secrets: [OPENAI_API_KEY], timeoutSeconds: 60 },
+  {
+    region: "us-central1",
+    minInstances: 1,
+    secrets: [OPENAI_API_KEY],
+    timeoutSeconds: 30,
+  },
   async (_req, res) => {
     if (!process.env.OPENAI_API_KEY) {
       return res.status(500).json({ ok: false, error: "Missing OPENAI_API_KEY" });


### PR DESCRIPTION
## Summary
- add boot log on module load
- keep one warm instance for all HTTP functions with 30s timeout
- ignore functions/.env at repo root

## Testing
- `npm --prefix functions test`


------
https://chatgpt.com/codex/tasks/task_e_68a4f8f26e608325832c62e62bd0d275