### PR TITLE
Use Firestore server timestamp in health check

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -75,7 +75,7 @@ export const firestoreHealth = onRequest(
       const ref = db.collection("ci-checks").doc("last-run");
       await ref.set(
         {
-          ranAt: new Date().toISOString(),
+          ranAt: FieldValue.serverTimestamp(),
           // record where this ran, for sanity
           projectId: app.options.projectId || "unknown",
           node: process.version,


### PR DESCRIPTION
## Summary
- ensure Firestore health check uses `FieldValue.serverTimestamp()` instead of a client-side date string
- functions already boot via modular Admin SDK with shared Firestore and verbose logging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a506ea84408325b30baa03a9a8d8a8