### PR TITLE
Electron hardening: Windows cache fix, IPC HTTP bridge, Vite input, Firebase client config

### DIFF
--- a/electron-app/src/main/preload.ts
+++ b/electron-app/src/main/preload.ts
@@ -1,4 +1,11 @@
-import { contextBridge } from 'electron';
+import { contextBridge, ipcRenderer } from 'electron';
+
 contextBridge.exposeInMainWorld('leadSync', {
-  ping: () => 'pong'
+  ping: () => 'pong',
+  /**
+   * Post JSON via the main process (electron.net). Avoids CORS.
+   */
+  postJson: async (url: string, headers: Record<string, string> = {}, payload: any = {}) => {
+    return ipcRenderer.invoke('http:post-json', { url, headers, body: payload });
+  },
 });

--- a/electron-app/src/renderer/firebase-config.ts
+++ b/electron-app/src/renderer/firebase-config.ts
@@ -1,0 +1,8 @@
+export const firebaseConfig = {
+  apiKey: "AIzaSyB0g7f_313m1pvVDA7hTQthldNTkjvrgF8",
+  authDomain: "priority-lead-sync.firebaseapp.com",
+  projectId: "priority-lead-sync",
+  storageBucket: "priority-lead-sync.appspot.com",
+  messagingSenderId: "155312316711",
+  appId: "1:155312316711:web:5728ed9367b192cc968902",
+};

--- a/electron-app/src/renderer/firestore.ts
+++ b/electron-app/src/renderer/firestore.ts
@@ -2,15 +2,7 @@ import { initializeApp } from 'firebase/app';
 import {
   getFirestore, collection, query, orderBy, limit, onSnapshot
 } from 'firebase/firestore';
-
-const firebaseConfig = {
-  apiKey: import.meta.env.APP_FIREBASE_API_KEY as string,
-  authDomain: import.meta.env.APP_FIREBASE_AUTH_DOMAIN as string,
-  projectId: import.meta.env.APP_FIREBASE_PROJECT_ID as string,
-  storageBucket: import.meta.env.APP_FIREBASE_STORAGE_BUCKET as string,
-  messagingSenderId: import.meta.env.APP_FIREBASE_MESSAGING_SENDER_ID as string,
-  appId: import.meta.env.APP_FIREBASE_APP_ID as string,
-};
+import { firebaseConfig } from './firebase-config';
 
 const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);

--- a/electron-app/vite.config.js
+++ b/electron-app/vite.config.js
@@ -8,6 +8,8 @@ export default defineConfig({
   build: {
     outDir: 'dist/renderer',
     emptyOutDir: true,
-    rollupOptions: { input: 'index.html' }
+    rollupOptions: {
+      input: 'src/renderer/index.html',
+    },
   }
 });


### PR DESCRIPTION
## Summary
- Keep Chromium cache and profile within writable project folders and add main-process HTTP bridge via electron.net to avoid CORS issues.
- Expose `leadSync.postJson` IPC helper in the preload script.
- Add public Firebase web config and initialize Firestore with it in the renderer.
- Point Vite's build input to `src/renderer/index.html`.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a609c838988325bf6006cdc2c298f8