### PR TITLE
Add Firestore leads rules and deployment scripts

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -8,6 +8,11 @@
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
   },
   "firestore": {
-    "rules": "firestore.rules"
+    "databases": [
+      {
+        "name": "leads",
+        "rules": "firestore.leads.rules"
+      }
+    ]
   }
 }

--- a/firestore.leads.rules
+++ b/firestore.leads.rules
@@ -1,0 +1,14 @@
+# This file is just a pointer copy. Do not edit directly in normal use.
+# Use npm scripts "rules:use:dev" or "rules:use:prod" to swap its contents.
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /leads_v2/{doc} {
+      allow read: if true;
+      allow write: if false;
+    }
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/firestore.leads.rules.dev
+++ b/firestore.leads.rules.dev
@@ -1,0 +1,16 @@
+rules_version = '2';
+service cloud.firestore {
+  // Named DB "leads"
+  match /databases/{database}/documents {
+    // TEMP DEV: let the Console and your Electron app READ leads
+    match /leads_v2/{doc} {
+      allow read: if true;       // <-- DEV convenience (read everything)
+      allow write: if false;     // <-- No client writes in dev
+    }
+
+    // Deny everything else
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/firestore.leads.rules.prod
+++ b/firestore.leads.rules.prod
@@ -1,0 +1,17 @@
+rules_version = '2';
+service cloud.firestore {
+  // Named DB "leads"
+  match /databases/{database}/documents {
+    // PRODUCTION: read only for authenticated users in our org
+    match /leads_v2/{doc} {
+      allow read: if request.auth != null
+                  && request.auth.token.email.matches('.*@priorityautomotive\\.com$');
+      allow write: if false;  // No client writes; server (Admin SDK) bypasses rules
+    }
+
+    // Deny everything else
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,4 +1,10 @@
 {
   "name": "priority-lead-sync",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "scripts": {
+    "rules:use:dev": "copy /Y firestore.leads.rules.dev firestore.leads.rules",
+    "rules:use:prod": "copy /Y firestore.leads.rules.prod firestore.leads.rules",
+    "deploy:rules:dev": "npm run rules:use:dev && firebase deploy --project priority-lead-sync --only firestore:rules:leads",
+    "deploy:rules:prod": "npm run rules:use:prod && firebase deploy --project priority-lead-sync --only firestore:rules:leads"
+  }
 }


### PR DESCRIPTION
## Summary
- Add development and production Firestore security rule files for the `leads` database
- Update `firebase.json` to deploy rules to the named `leads` database
- Add npm scripts for swapping rule sets and deploying them

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a64cb33e548325a12e371d296d3df4