### PR TITLE
Use Firestore leads database across project

### DIFF
--- a/electron-app/src/renderer/firestore.ts
+++ b/electron-app/src/renderer/firestore.ts
@@ -6,7 +6,7 @@ let _db;
 export function connect() {
   if (!_db) {
     const app = initializeApp(firebaseWebConfig);
-    _db = getFirestore(app);
+    _db = getFirestore(app, "leads");
   }
   return _db;
 }

--- a/firebase.json
+++ b/firebase.json
@@ -1,10 +1,7 @@
 {
   "firestore": {
     "rules": [
-      {
-        "target": "leads",
-        "rules": "firestore.rules"
-      }
+      { "database": "leads", "rules": "firestore.rules" }
     ]
   }
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -2,15 +2,16 @@
 import { onRequest } from "firebase-functions/v2/https";
 import { defineSecret } from "firebase-functions/params";
 import * as admin from "firebase-admin";
+import { getFirestore } from "firebase-admin/firestore";
 import { google } from "googleapis";
 import { parseStringPromise } from "xml2js";
 
 if (!admin.apps.length) {
   admin.initializeApp({
-    projectId: "priority-lead-sync" // binds project; uses DEFAULT Firestore DB
+    projectId: "priority-lead-sync"
   });
 }
-const db = admin.firestore();
+const db = getFirestore(undefined, "leads");
 
 /** ---------- Secrets (mounted from Secret Manager at runtime) ---------- */
 const GMAIL_WEBHOOK_SECRET = defineSecret("GMAIL_WEBHOOK_SECRET");
@@ -59,7 +60,7 @@ export const testSecrets = onRequest(
   }
 );
 
-/** ---------- Firestore health: default DB (no custom databaseId) ---------- */
+/** ---------- Firestore health: "leads" DB ---------- */
 export const firestoreHealth = onRequest({ region: "us-central1" }, async (_req, res) => {
   try {
     const ref = db.collection("ci-checks").doc("last-run");

--- a/scripts/run-admin.cjs
+++ b/scripts/run-admin.cjs
@@ -23,8 +23,7 @@ try {
 }
 
 const databaseId = process.env.FIRESTORE_DATABASE_ID || 'leads';
-const db = getFirestore();
-db.settings({ databaseId }); // target non-default DB immediately
+const db = getFirestore(undefined, databaseId);
 
 (async () => {
   try {


### PR DESCRIPTION
## Summary
- Scope Firestore rules to the `leads` database and drop default DB references
- Initialize Cloud Functions, Electron client, and admin scripts against `leads`

## Testing
- `cd functions && npm test`
- `cd electron-app && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9fc4423dc83258361644005b99699