### PR TITLE
feat: add listLeads endpoint and polling client

### DIFF
--- a/electron-app/src/renderer/firebase-config.ts
+++ b/electron-app/src/renderer/firebase-config.ts
@@ -1,10 +1,11 @@
 // electron-app/src/renderer/firebase-config.ts
-import { initializeApp } from "firebase/app";
-import { getFirestore } from "firebase/firestore";
+export const BASE_URL = (import.meta as any).env?.VITE_WEBHOOK_BASE_URL || "https://receiveemaillead-puboig54jq-uc.a.run.app";
+export const API_BASE = BASE_URL.replace("/receiveemaillead", ""); // if BASE_URL is the webhook, we strip for others
+export const SECRET  = (import.meta as any).env?.VITE_WEBHOOK_SECRET || "PriorityLead2025SecretKey";
 
-export const app = initializeApp({
-  apiKey: "AIzaSyB0g7f_313m1pvVDA7hTQthldNTkjvrgF8",
-  authDomain: "priority-lead-sync.firebaseapp.com",
-  projectId: "priority-lead-sync",
-});
-export const db = getFirestore(app); // default DB only
+// Endpoints
+export const ENDPOINTS = {
+  listLeads: `${API_BASE}/listleads`,
+  webhook:   `${API_BASE}/receiveemaillead`
+};
+

--- a/electron-app/src/renderer/index.html
+++ b/electron-app/src/renderer/index.html
@@ -7,13 +7,8 @@
   </head>
   <body>
     <h1>Priority Lead Sync</h1>
-    <div id="status">
-      <div>Firestore: <span id="fs-state">…</span></div>
-      <div>Lead count (live): <span id="lead-count">0</span></div>
-      <button id="send-test">Send Test Lead</button>
-      <pre id="last-result"></pre>
-    </div>
-    <ul id="leads"></ul>
+    <ul id="lead-list"></ul>
     <script type="module" src="/src/renderer/bootstrap.ts"></script>
   </body>
 </html>
+

--- a/electron-app/src/renderer/store.ts
+++ b/electron-app/src/renderer/store.ts
@@ -1,16 +1,3 @@
-const KEY = 'leadsync-last-seen';
+// simple in-memory Set to avoid duplicate notifications
+export const seenStore = new Set<string>();
 
-export function saveLastSeen(id: string) {
-  const list = load();
-  if (!list.includes(id)) list.unshift(id);
-  localStorage.setItem(KEY, JSON.stringify(list.slice(0, 200)));
-}
-
-export function wasSeen(id: string): boolean {
-  return load().includes(id);
-}
-
-function load(): string[] {
-  try { return JSON.parse(localStorage.getItem(KEY) || '[]'); }
-  catch { return []; }
-}


### PR DESCRIPTION
## Summary
- initialize Admin SDK against named Firestore DB `leads`
- add secure `listLeads` function for recent leads
- replace Electron renderer's Firestore client with polling

## Testing
- `npm test --prefix functions --silent`
- `npm test --prefix electron-app --silent`

------
https://chatgpt.com/codex/tasks/task_e_68aa3eba00f08325af6cb382f1eb4809