### PR TITLE
Switch to first-gen Cloud Functions

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -1,18 +1,15 @@
 {
   "name": "priority-lead-sync-functions",
-  "type": "module",
   "private": true,
+  "type": "module",
   "engines": { "node": "20" },
   "main": "index.js",
-  "scripts": {
-    "deploy:all": "firebase deploy --project priority-lead-sync --only functions",
-    "deploy:webhook": "firebase deploy --project priority-lead-sync --only functions:receiveEmailLead",
-    "deploy:list": "firebase deploy --project priority-lead-sync --only functions:listLeads",
-    "deploy:health": "firebase deploy --project priority-lead-sync --only functions:health,functions:firestoreHealth,functions:gmailHealth,functions:testSecrets"
-  },
   "dependencies": {
     "firebase-admin": "^12.6.0",
     "firebase-functions": "^5.1.1",
     "xml2js": "^0.6.2"
+  },
+  "scripts": {
+    "deploy:all": "firebase deploy --project priority-lead-sync --only functions"
   }
 }


### PR DESCRIPTION
## Summary
- Replace v2 Cloud Functions with 1st-gen implementation, binding Firestore Admin to the existing `leads` database and reading secrets from environment variables.
- Simplify functions package configuration for v1 compatibility.
- Harden webhook authentication by using a timing-safe comparison for the secret.

## Testing
- `cd functions && npx --yes jest`


------
https://chatgpt.com/codex/tasks/task_e_68add7bc1cbc8325b19f328f3be80169